### PR TITLE
feat: ignore invalid host configuration on the dockerconfigjson

### DIFF
--- a/src/registry/config.rs
+++ b/src/registry/config.rs
@@ -17,14 +17,14 @@ pub struct DockerConfigRaw {
     auths: HashMap<String, RegistryAuthRaw>,
 }
 
-#[derive(Clone, Debug)]
-pub(crate) enum RegistryAuth {
+#[derive(Clone, Debug, PartialEq)]
+pub enum RegistryAuth {
     BasicAuth(Vec<u8>, Vec<u8>),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct DockerConfig {
-    pub(crate) auths: HashMap<String, RegistryAuth>,
+    pub auths: HashMap<String, RegistryAuth>,
 }
 
 impl TryFrom<DockerConfigRaw> for DockerConfig {
@@ -36,9 +36,7 @@ impl TryFrom<DockerConfigRaw> for DockerConfig {
                 .auths
                 .into_iter()
                 .filter_map(|(host, auth)| match OptionalRegistryAuth::try_from(auth) {
-                    Ok(registry_auth) => {
-                        registry_auth.map(|registry_auth| Ok((host, registry_auth)))
-                    }
+                    Ok(registry_auth) => registry_auth.map(|registry_auth| (host, registry_auth)),
                     Err(e) => {
                         eprintln!(
                             "error parsing host {} configuration: {}; host ignored",
@@ -47,7 +45,7 @@ impl TryFrom<DockerConfigRaw> for DockerConfig {
                         None
                     }
                 })
-                .collect::<Result<_>>()?,
+                .collect(),
         })
     }
 }

--- a/src/registry/config.rs
+++ b/src/registry/config.rs
@@ -4,7 +4,12 @@ use std::{collections::HashMap, convert::TryFrom, convert::TryInto, fs::File, pa
 
 #[derive(Deserialize, Debug)]
 pub(crate) struct RegistryAuthRaw {
-    auth: String,
+    // `auth` is optional because we have to be liberal on what we
+    // accept: a tool or a user might change the configuration file in
+    // disk and end up with a syntactically valid JSON, but
+    // semantically invalid. Check:
+    // https://github.com/kubernetes/kubectl/issues/571
+    auth: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -30,30 +35,83 @@ impl TryFrom<DockerConfigRaw> for DockerConfig {
             auths: docker_config
                 .auths
                 .into_iter()
-                .map(|(host, auth)| Ok((host, RegistryAuth::try_from(auth)?)))
+                .filter_map(|(host, auth)| match OptionalRegistryAuth::try_from(auth) {
+                    Ok(registry_auth) => {
+                        registry_auth.map(|registry_auth| Ok((host, registry_auth)))
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "error parsing host {} configuration: {}; host ignored",
+                            host, e
+                        );
+                        None
+                    }
+                })
                 .collect::<Result<_>>()?,
         })
     }
 }
 
-impl TryFrom<RegistryAuthRaw> for RegistryAuth {
+type OptionalRegistryAuth = Option<RegistryAuth>;
+
+impl TryFrom<RegistryAuthRaw> for OptionalRegistryAuth {
     type Error = anyhow::Error;
 
     fn try_from(auth: RegistryAuthRaw) -> Result<Self> {
-        if let Ok(basic_auth) = base64::decode(auth.auth) {
-            let splitted: Vec<&[u8]> = basic_auth.split(|c| *c == b':').collect();
-            if splitted.len() == 2 {
-                let (username, password) = (splitted[0], splitted[1]);
-                Ok(RegistryAuth::BasicAuth(username.into(), password.into()))
+        if let Some(auth) = auth.auth {
+            if let Ok(basic_auth) = base64::decode(auth) {
+                let splitted: Vec<&[u8]> = basic_auth.split(|c| *c == b':').collect();
+                if splitted.len() == 2 {
+                    let (username, password) = (splitted[0], splitted[1]);
+                    Ok(Some(RegistryAuth::BasicAuth(
+                        username.into(),
+                        password.into(),
+                    )))
+                } else {
+                    Err(anyhow!("basic auth not in the form username:password"))
+                }
             } else {
-                Err(anyhow!("basic auth not in the form username:password"))
+                Err(anyhow!("invalid base64 encoding"))
             }
         } else {
-            Err(anyhow!("invalid base64 encoding"))
+            Ok(None)
         }
     }
 }
 
 pub fn read_docker_config_json_file(path: &Path) -> Result<DockerConfig> {
     serde_json::from_reader::<_, DockerConfigRaw>(File::open(path)?)?.try_into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::iter::FromIterator;
+
+    #[test]
+    fn test_missing_auth_key() -> Result<()> {
+        let auths = vec![
+            (
+                "auth-registry.example.com".to_string(),
+                RegistryAuthRaw {
+                    // echo -n "username:password" | base64 -w0
+                    auth: Some("dXNlcm5hbWU6cGFzc3dvcmQ=".to_string()),
+                },
+            ),
+            (
+                "authless-registry.example.com".to_string(),
+                RegistryAuthRaw { auth: None },
+            ),
+        ];
+
+        let docker_config: DockerConfig = DockerConfigRaw {
+            auths: HashMap::from_iter(auths),
+        }
+        .try_into()?;
+
+        assert_eq!(docker_config.auths.len(), 1);
+
+        Ok(())
+    }
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,0 +1,17 @@
+use std::{fs::read_to_string, path::Path};
+
+#[allow(dead_code)]
+pub(crate) fn test_data(filename: &Path) -> String {
+    let test_data_file = std::env::current_dir()
+        .expect(&format!(
+            "[test setup error] could not read the current directory"
+        ))
+        .join("tests")
+        .join("test_data")
+        .join(filename);
+
+    read_to_string(&test_data_file).expect(&format!(
+        "[test setup error] could not read file {:?}",
+        &test_data_file
+    ))
+}

--- a/tests/parse_docker_config_json.rs
+++ b/tests/parse_docker_config_json.rs
@@ -1,0 +1,39 @@
+mod common;
+
+use common::test_data;
+use policy_fetcher::registry::config::{DockerConfig, DockerConfigRaw, RegistryAuth};
+use std::{collections::HashMap, convert::TryInto, iter::FromIterator, path::Path};
+
+fn docker_config(test_data_file: &str) -> DockerConfig {
+    let test_data_contents = test_data(Path::new(test_data_file));
+    serde_json::from_str::<DockerConfigRaw>(&test_data_contents)
+        .expect("could not unmarshal config file")
+        .try_into()
+        .expect("could not convert external config to internal type")
+}
+
+#[test]
+fn parses_with_auth_present() {
+    assert_eq!(
+        docker_config("auth-present.json"),
+        DockerConfig {
+            auths: HashMap::from_iter(vec![(
+                "https://index.docker.io/v1/".to_string(),
+                RegistryAuth::BasicAuth("username".into(), "token".into())
+            )])
+        }
+    )
+}
+
+#[test]
+fn parses_with_some_auth_missing() {
+    assert_eq!(
+        docker_config("auth-some-missing.json"),
+        DockerConfig {
+            auths: HashMap::from_iter(vec![(
+                "example.registry.com".to_string(),
+                RegistryAuth::BasicAuth("username".into(), "token".into())
+            ),])
+        }
+    )
+}

--- a/tests/test_data/auth-present.json
+++ b/tests/test_data/auth-present.json
@@ -1,0 +1,10 @@
+{
+  "auths": {
+    "https://index.docker.io/v1/": {
+      "auth": "dXNlcm5hbWU6dG9rZW4="
+    }
+  },
+  "HttpHeaders": {
+    "User-Agent": "Docker-Client/19.03.15 (linux)"
+  }
+}

--- a/tests/test_data/auth-some-missing.json
+++ b/tests/test_data/auth-some-missing.json
@@ -1,0 +1,11 @@
+{
+  "auths": {
+    "https://index.docker.io/v1/": {},
+    "example.registry.com": {
+      "auth": "dXNlcm5hbWU6dG9rZW4="
+    }
+  },
+  "HttpHeaders": {
+    "User-Agent": "Docker-Client/19.03.15 (linux)"
+  }
+}


### PR DESCRIPTION
Fixes: https://github.com/kubewarden/kwctl/issues/47

`kubectl` has generated docker config json files that miss the `auth`
key in the `auths` field [1].

Due to this, make the parsing of the dockerconfigjson file less
strict, with an optional `auth` field. If this field is not present,
the host will be ignored, but the rest of the file will apply.

We keep the same behavior of a complete failure in the following
cases:

- The JSON file is not syntactically valid
- The basic auth information is not valid base64
- The decoded base64 is not in the form `username:password`.

[1] https://github.com/kubernetes/kubectl/issues/571