### PR TITLE
Check host+port when checking for insecure hosts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ pub async fn fetch_policy(
     let sources = sources.unwrap_or(&sources_default);
 
     if let Err(err) = policy_fetcher
-        .fetch(&url, client_protocol(&url, &sources)?, &destination)
+        .fetch(&url, client_protocol(&url, sources)?, &destination)
         .await
     {
         if !sources.is_insecure_source(&host_and_port(&url)?) {
@@ -118,7 +118,7 @@ pub async fn fetch_policy(
 }
 
 fn client_protocol(url: &Url, sources: &Sources) -> Result<ClientProtocol> {
-    if let Some(certificates) = sources.source_authority(&host_and_port(&url)?) {
+    if let Some(certificates) = sources.source_authority(&host_and_port(url)?) {
         return Ok(ClientProtocol::Https(
             TlsVerificationMode::CustomCaCertificates(certificates),
         ));
@@ -141,7 +141,7 @@ fn pull_destination(url: &Url, destination: &PullDestination) -> Result<(Option<
             (Some(store), policy_path)
         }
         PullDestination::LocalFile(destination) => {
-            if Path::is_dir(&destination) {
+            if Path::is_dir(destination) {
                 let filename = url.path().split('/').last().unwrap();
                 (None, destination.join(filename))
             } else {

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -123,7 +123,7 @@ impl Registry {
                 if !sources
                     .clone()
                     .unwrap_or_default()
-                    .is_insecure_source(url.host_str().unwrap_or_default())
+                    .is_insecure_source(&crate::host_and_port(&url)?)
                 {
                     return Err(anyhow!("could not push policy: {}", err,));
                 }


### PR DESCRIPTION
If port is present, check `host+port` in the insecure hosts mapping to
determine if we should retry the pull/push.