### PR TITLE
Embrace the tracing crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ rustls = "0.19.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.64"
 serde_yaml = "0.8.15"
+tracing = "0.1.29"
 url = "2.2.0"
 walkdir = "2"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ use crate::store::Store;
 use oci_distribution::Reference;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use tracing::debug;
 use url::ParseError;
 
 #[derive(Debug)]
@@ -82,7 +83,7 @@ pub async fn fetch_policy(
         }
         _ => unreachable!(),
     }
-    eprintln!("pulling policy...");
+    debug!(?url, "pulling policy");
     let policy_fetcher = url_fetcher(url.scheme(), docker_config)?;
     let sources_default = Sources::default();
     let sources = sources.unwrap_or(&sources_default);

--- a/src/registry/config.rs
+++ b/src/registry/config.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Result};
 use serde::Deserialize;
 use std::{collections::HashMap, convert::TryFrom, convert::TryInto, fs::File, path::Path};
+use tracing::error;
 
 #[derive(Deserialize, Debug)]
 pub(crate) struct RegistryAuthRaw {
@@ -38,9 +39,10 @@ impl TryFrom<DockerConfigRaw> for DockerConfig {
                 .filter_map(|(host, auth)| match OptionalRegistryAuth::try_from(auth) {
                     Ok(registry_auth) => registry_auth.map(|registry_auth| (host, registry_auth)),
                     Err(e) => {
-                        eprintln!(
-                            "error parsing host {} configuration: {}; host ignored",
-                            host, e
+                        error!(
+                            host = %host,
+                            error = %e,
+                            "error parsing host configuration, host ignored",
                         );
                         None
                     }


### PR DESCRIPTION
Do not print messages/errors on the stdout/stderr. Instead use the tracing crate.

Fixes #13
