### PR TITLE
fix: Deserialize RawSources correctly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,4 @@ walkdir = "2"
 
 [dev-dependencies]
 tempfile = "3.2.0"
+textwrap = "0.11.0"


### PR DESCRIPTION
Use an internally tagged struct for RawSourceAuthority, insted of a
Serde untagged one.

Refactor RawCertificate into a wrapper of String instead of Vec<u8>, so
we can deserialize string and string blocks from JSON.

Add unit test for `pub fn read_sources_file(path)`.