### PR TITLE
feat!: Add `verifier::verify_local_file_checksum()`, return manifests on `verifier::verify()`

### DIFF
--- a/src/verify.rs
+++ b/src/verify.rs
@@ -36,10 +36,9 @@ impl Verifier {
     /// When annotations are provided, they are enforced with the values specified
     /// inside of the Sigstore signature object.
     ///
-    /// Finally, this method checks whether the specified policy already exists
-    /// on the local file system. When that happens, the checksum of the local file
-    /// is compared with the one mentioned inside of the signed (and verified) manifest.
-    /// That ensures nobody tampered the local policy.
+    /// Note well: this method doesn't compare the checksum of a possible local
+    /// file with the one inside of the signed (and verified) manifest, as that
+    /// can only be done with certainty after pulling the policy.
     ///
     /// Note well: right now, verification can be done only against policies that are
     /// stored inside of OCI registries.
@@ -108,8 +107,6 @@ impl Verifier {
             .image
             .docker_manifest_digest;
 
-        self.verify_local_file_checksum(&url, image_name, docker_config, manifest_digest)
-            .await
     }
 
     /// Compares the checksum of the local policy with the one mentioned inside of the

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -37,6 +37,8 @@ impl Verifier {
     /// When annotations are provided, they are enforced with the values
     /// specified inside of the Sigstore signature object.
     ///
+    /// In case of success, returns the manifest digest of the verified policy.
+    ///
     /// Note well: this method doesn't compare the checksum of a possible local
     /// file with the one inside of the signed (and verified) manifest, as that
     /// can only be done with certainty after pulling the policy.

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -31,24 +31,25 @@ impl Verifier {
         }
     }
 
-    /// Verifies the given policy using the verification key provided by the user.
+    /// Verifies the given policy using the verification key provided by the
+    /// user.
     ///
-    /// When annotations are provided, they are enforced with the values specified
-    /// inside of the Sigstore signature object.
+    /// When annotations are provided, they are enforced with the values
+    /// specified inside of the Sigstore signature object.
     ///
     /// Note well: this method doesn't compare the checksum of a possible local
     /// file with the one inside of the signed (and verified) manifest, as that
     /// can only be done with certainty after pulling the policy.
     ///
-    /// Note well: right now, verification can be done only against policies that are
-    /// stored inside of OCI registries.
+    /// Note well: right now, verification can be done only against policies
+    /// that are stored inside of OCI registries.
     pub async fn verify(
         &mut self,
         url: &str,
         docker_config: Option<DockerConfig>,
         annotations: Option<HashMap<String, String>>,
         verification_key: &str,
-    ) -> Result<()> {
+    ) -> Result<String> {
         let url = match Url::parse(url) {
             Ok(u) => Ok(u),
             Err(ParseError::RelativeUrlWithoutBase) => {
@@ -100,13 +101,15 @@ impl Verifier {
         // cosign_client.verify raises an error if no SimpleSigning
         // object is found -> the vector has at least one entry.
         // Finally, all the entries have the same docker_manifest_digest
-        let manifest_digest = &simple_signing_matches
+        let manifest_digest = simple_signing_matches
             .get(0)
             .unwrap()
             .critical
             .image
-            .docker_manifest_digest;
+            .docker_manifest_digest
+            .clone();
 
+        Ok(manifest_digest)
     }
 
     /// Compares the checksum of the local policy with the one mentioned inside of the


### PR DESCRIPTION
Add `verifier::verify_local_file_checksum()`. As input, it uses a verified manifest digest. That way the callers are
aware that this function should only be called on verified policies.

Refactor with breaking change: Return verified manifest digest in `verifier::verify()`, and don't silently compare checksums there.

Needed by https://github.com/kubewarden/kwctl/pull/84.