### PR TITLE
expose fetch manifest digest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-fetcher"
-version = "0.1.18"
+version = "0.2.0"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,7 @@ fn url_fetcher(
     match scheme {
         "file" => Ok(Box::new(Local::default())),
         "http" | "https" => Ok(Box::new(Https::default())),
-        "registry" => Ok(Box::new(Registry::new(&docker_config))),
+        "registry" => Ok(Box::new(Registry::new(docker_config.as_ref()))),
         _ => return Err(anyhow!("unknown scheme: {}", scheme)),
     }
 }

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -82,9 +82,9 @@ impl From<ClientProtocol> for ClientConfig {
 }
 
 impl Registry {
-    pub fn new(docker_config: &Option<DockerConfig>) -> Registry {
+    pub fn new(docker_config: Option<&DockerConfig>) -> Registry {
         Registry {
-            docker_config: docker_config.clone(),
+            docker_config: docker_config.map(|dc| dc.clone()),
         }
     }
 
@@ -109,17 +109,18 @@ impl Registry {
 
     /// Fetch the manifest of the OCI object referenced by the given url.
     /// The url is expected to be in the "registry://" format.
-    pub(crate) async fn manifest(
+    pub async fn manifest(
         &self,
         url: &str,
-        sources: &Option<Sources>,
+        sources: Option<&Sources>,
     ) -> Result<oci_distribution::manifest::OciManifest> {
         let url = Url::parse(url).map_err(|_| anyhow!("invalid URL: {}", url))?;
         let reference =
             Reference::from_str(url.as_ref().strip_prefix("registry://").unwrap_or_default())?;
 
         let registry_auth = Registry::auth(reference.registry(), self.docker_config.as_ref());
-        let cp = crate::client_protocol(&url, &sources.clone().unwrap_or_default())?;
+        let sources: Sources = sources.map(|s| s.clone()).unwrap_or_default();
+        let cp = crate::client_protocol(&url, &sources)?;
 
         let (m, _) = Registry::client(cp)
             .pull_manifest(&reference, &registry_auth)
@@ -128,24 +129,17 @@ impl Registry {
         Ok(m)
     }
 
-    pub async fn push(&self, policy: &[u8], url: &str, sources: &Option<Sources>) -> Result<()> {
+    pub async fn push(&self, policy: &[u8], url: &str, sources: Option<&Sources>) -> Result<()> {
         let url = Url::parse(url).map_err(|_| anyhow!("invalid URL: {}", url))?;
+        let sources: Sources = sources.map(|s| s.clone()).unwrap_or_default();
 
         match self
-            .do_push(
-                policy,
-                &url,
-                crate::client_protocol(&url, &sources.clone().unwrap_or_default())?,
-            )
+            .do_push(policy, &url, crate::client_protocol(&url, &sources)?)
             .await
         {
             Ok(_) => return Ok(()),
             Err(err) => {
-                if !sources
-                    .clone()
-                    .unwrap_or_default()
-                    .is_insecure_source(&crate::host_and_port(&url)?)
-                {
+                if !sources.is_insecure_source(&crate::host_and_port(&url)?) {
                     return Err(anyhow!("could not push policy: {}", err,));
                 }
             }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -148,7 +148,7 @@ impl Verifier {
             return Err(anyhow!("No local policy to verify the manifest for"));
         }
 
-        let registry = crate::registry::Registry::new(&docker_config);
+        let registry = crate::registry::Registry::new(docker_config.as_ref());
         let reference = oci_distribution::Reference::from_str(image_name)?;
         let image_immutable_ref = format!(
             "registry://{}/{}@{}",
@@ -157,7 +157,7 @@ impl Verifier {
             verified_manifest_digest
         );
         let manifest = registry
-            .manifest(&image_immutable_ref, &self.sources.clone())
+            .manifest(&image_immutable_ref, self.sources.as_ref())
             .await?;
 
         let digests: Vec<String> = manifest


### PR DESCRIPTION
Expose a method to fetch the manifest digest. This is needed so that we can expose this function to our policies.

While at that, I also did some refactoring of function params: from `&Option<T>` to `Option<&T>`.
