### PR TITLE
Handle operations against Docker Hub

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ base64 = "0.13.0"
 directories = "3.0.2"
 lazy_static = "1.4.0"
 #oci-distribution = "0.6"
-oci-distribution = { git = "https://github.com/kubewarden/krustlet", branch = "oci-distribution-fix-push-to-ghcr"}
+oci-distribution = { git = "https://github.com/kubewarden/oci-distribution", branch = "not-yet-merged-patches" }
 reqwest = { version = "0.11.3", features = ["rustls"] }
 rustls = "0.19.1"
 serde_json = "1.0.64"
@@ -31,5 +31,6 @@ url = "2.2.0"
 walkdir = "2"
 
 [dev-dependencies]
+rstest = "0.11.0"
 tempfile = "3.2.0"
 textwrap = "0.11.0"

--- a/src/fetcher.rs
+++ b/src/fetcher.rs
@@ -5,13 +5,13 @@ use url::Url;
 
 use crate::sources::Certificate;
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) enum ClientProtocol {
     Http,
     Https(TlsVerificationMode),
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) enum TlsVerificationMode {
     CustomCaCertificates(Vec<Certificate>),
     SystemCa,


### PR DESCRIPTION
Some of the methods of the `Registry` struct are going to be used against container images, not kubewarden policies.

For example, this will happen to the methods dealing with OCI objects manifests (regardless of them being images or artifacts).
A policy might rely on this method to obtain the digest of a container image that is mentioned inside of a Pod `spec` section.

We have no control over these container images, they could also be images coming from the Docker Hub or even from the "Docker Hub library".
That means that we must be able to handle OCI object names like `busybox`, `opensuse/leap`.

This commits makes `policy-fetcher` rely on a forked version of `oci-distribution`.
This is needed because some important fixes related with image parsing have not yet been released.

Some parts of our code had to be changed. We should not build a `Url` starting from the user input, but rather use `oci-distribution` to resolve the image name and then feed that into a `Url`.

Why that? A simple example: prior to this commit, a user input of `registry://busybox:latest` would have caused an error when building the `Url` object. That's because this string is not a properly formatted
url.

We have instead to:

  1. Resolve `busybox:latest` using `oci-distribution`.
  2. This will return `docker.io/busybox/library:latest` as image name.
  2. Create a `Url` with the fully resolved name.

Note well, the new image resolution algorithm of `oci-distribution` automatically appends the `:latest` tag to an image when needed.
Because of that some of our code had to be removed/refactored.

This is needed as part of the epic that plans to expose "image manifest related" operations to our policies.

