### PR TITLE
push return immutable ref

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,9 @@ async-trait = "0.1.50"
 base64 = "0.13.0"
 directories = "3.0.2"
 lazy_static = "1.4.0"
-oci-distribution = { version = "0.8.1", default-features = false, features =  ["rustls-tls"] }
+#oci-distribution = { version = "0.8.1", default-features = false, features =  ["rustls-tls"] }
+oci-distribution = { git = "https://github.com/kubewarden/oci-distribution", branch = "not-yet-merged-patches", default-features = false, features =  ["rustls-tls"] }
+regex = "1.5.4"
 reqwest = { version = "0.11.3", default-features = false, features = ["rustls-tls"] }
 rustls = "0.19.1"
 serde_json = "1.0.64"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-fetcher"
-version = "0.3.1"
+version = "0.4.0"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>"
@@ -17,7 +17,6 @@ async-trait = "0.1.50"
 base64 = "0.13.0"
 directories = "3.0.2"
 lazy_static = "1.4.0"
-#oci-distribution = { version = "0.8.1", default-features = false, features =  ["rustls-tls"] }
 oci-distribution = { git = "https://github.com/kubewarden/oci-distribution", branch = "not-yet-merged-patches", default-features = false, features =  ["rustls-tls"] }
 regex = "1.5.4"
 reqwest = { version = "0.11.3", default-features = false, features = ["rustls-tls"] }

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, Result};
 use async_std::fs::File;
 use async_std::prelude::*;
 use async_trait::async_trait;
+use lazy_static::lazy_static;
 use oci_distribution::{
     client::{
         Certificate as OciCertificate, CertificateEncoding, Client, ClientConfig,
@@ -11,6 +12,7 @@ use oci_distribution::{
     secrets::RegistryAuth,
     Reference,
 };
+use regex::Regex;
 use std::convert::TryFrom;
 use std::{path::Path, str::FromStr};
 use tracing::debug;
@@ -21,6 +23,11 @@ use crate::registry::config::{DockerConfig, RegistryAuth as OwnRegistryAuth};
 use crate::sources::{Certificate, Sources};
 
 pub mod config;
+
+lazy_static! {
+    static ref SHA256_DIGEST_RE: Regex = Regex::new(r"[A-Fa-f0-9]{64}").unwrap();
+    static ref SHA512_DIGEST_RE: Regex = Regex::new(r"[A-Fa-f0-9]{128}").unwrap();
+}
 
 // Struct used to reference a WASM module that is hosted on an OCI registry
 #[derive(Default)]
@@ -146,15 +153,29 @@ impl Registry {
             .await
     }
 
-    pub async fn push(&self, policy: &[u8], url: &str, sources: Option<&Sources>) -> Result<()> {
-        let url = Url::parse(url).map_err(|_| anyhow!("invalid URL: {}", url))?;
+    /// Push the policy to the OCI registry specified by `url`.
+    ///
+    /// Returns the immutable reference to the policy (i.e.
+    /// `ghcr.io/kubewarden/secure-policy@sha256:72b4569c3daee67abeaa64192fb53895d0edb2d44fa6e1d9d4c5d3f8ece09f6e`)
+    pub async fn push(
+        &self,
+        policy: &[u8],
+        destination: &str,
+        sources: Option<&Sources>,
+    ) -> Result<String> {
+        let url = Url::parse(destination).map_err(|_| anyhow!("invalid URL: {}", destination))?;
         let sources: Sources = sources.cloned().unwrap_or_default();
+        let destination = destination
+            .strip_prefix("registry://")
+            .ok_or_else(|| anyhow!("Invalid destination format"))?;
 
         match self
             .do_push(policy, &url, crate::client_protocol(&url, &sources)?)
             .await
         {
-            Ok(_) => return Ok(()),
+            Ok(manifest_url) => {
+                return build_immutable_ref(destination, &manifest_url);
+            }
             Err(err) => {
                 if !sources.is_insecure_source(&crate::host_and_port(&url)?) {
                     return Err(anyhow!("could not push policy: {}", err,));
@@ -162,21 +183,23 @@ impl Registry {
             }
         }
 
-        if self
+        if let Ok(manifest_url) = self
             .do_push(
                 policy,
                 &url,
                 ClientProtocol::Https(TlsVerificationMode::NoTlsVerification),
             )
             .await
-            .is_ok()
         {
-            return Ok(());
+            return build_immutable_ref(destination, &manifest_url);
         }
 
-        self.do_push(policy, &url, ClientProtocol::Http)
+        let manifest_url = self
+            .do_push(policy, &url, ClientProtocol::Http)
             .await
-            .map_err(|_| anyhow!("could not push policy"))
+            .map_err(|_| anyhow!("could not push policy"))?;
+
+        build_immutable_ref(destination, &manifest_url)
     }
 
     async fn do_push(
@@ -184,7 +207,7 @@ impl Registry {
         policy: &[u8],
         url: &Url,
         client_protocol: ClientProtocol,
-    ) -> Result<()> {
+    ) -> Result<String> {
         let reference =
             Reference::from_str(url.as_ref().strip_prefix("registry://").unwrap_or_default())?;
 
@@ -206,7 +229,7 @@ impl Registry {
                 None,
             )
             .await
-            .map(|_| ())
+            .map(|push_response| push_response.manifest_url)
             .map_err(|e| anyhow!("could not push policy: {}", e))
     }
 }
@@ -255,6 +278,59 @@ impl PolicyFetcher for Registry {
             None => Err(anyhow!("could not pull policy {}", url)),
         }
     }
+}
+
+/// Buidls an immutable OCI reference for the given image
+///
+/// * `image ref`: the mutable image reference. For example: `ghcr.io/kubewarden/secure-policy:latest`
+/// * `manifest_url`: the URL of the manifest, as returned when doing a push operation. For example
+///   `https://ghcr.io/v2/kubewarden/secure-policy/manifests/sha256:72b4569c3daee67abeaa64192fb53895d0edb2d44fa6e1d9d4c5d3f8ece09f6e`
+fn build_immutable_ref(image_ref: &str, manifest_url: &str) -> Result<String> {
+    let manifest_digest = manifest_url
+        .rsplit_once('/')
+        .map(|(_, digest)| digest.to_string())
+        .ok_or_else(|| {
+            anyhow!(
+                "Cannot extract manifest digest from the OCI registry response: {}",
+                manifest_url
+            )
+        })?;
+
+    let (digest, checksum) = manifest_digest
+        .split_once(':')
+        .ok_or_else(|| anyhow!("Invalid digest: {}", manifest_digest))?;
+
+    let digest_valid = match digest {
+        "sha256" => Ok(SHA256_DIGEST_RE.is_match(checksum)),
+        "sha512" => Ok(SHA512_DIGEST_RE.is_match(checksum)),
+        unknown => Err(anyhow!(
+            "unknown algorithm '{}' for manifest {}",
+            unknown,
+            manifest_digest
+        )),
+    }?;
+
+    if !digest_valid {
+        return Err(anyhow!(
+            "The digest of the returned manifest is not valid: {}",
+            manifest_digest
+        ));
+    }
+
+    let oci_reference = oci_distribution::Reference::try_from(image_ref)?;
+    let mut image_immutable_ref = if oci_reference.registry() == "" {
+        oci_reference.repository().to_string()
+    } else {
+        format!(
+            "{}/{}",
+            oci_reference.registry(),
+            oci_reference.repository()
+        )
+    };
+    image_immutable_ref.push('@');
+    image_immutable_ref.push_str(&manifest_digest);
+
+    Ok(image_immutable_ref)
 }
 
 #[cfg(test)]
@@ -333,5 +409,56 @@ mod tests {
         assert_eq!(repository, reference.repository(), "input was: {}", input);
         assert_eq!(tag, reference.tag(), "input was: {}", input);
         assert_eq!(digest, reference.digest(), "input was: {}", input);
+    }
+
+    #[rstest(
+        image_ref,
+        manifest_url,
+        immutable_ref,
+        case(
+            "ghcr.io/kubewarden/secure-policy:latest",
+            "https://ghcr.io/v2/kubewarden/secure-policy/manifests/sha256:72b4569c3daee67abeaa64192fb53895d0edb2d44fa6e1d9d4c5d3f8ece09f6e",
+            Ok(String::from("ghcr.io/kubewarden/secure-policy@sha256:72b4569c3daee67abeaa64192fb53895d0edb2d44fa6e1d9d4c5d3f8ece09f6e")),
+        ),
+        case(
+            "ghcr.io/kubewarden/secure-policy:latest",
+            "https://ghcr.io/v2/kubewarden/secure-policy/manifests/sha512:76ffb94a4cfdc6663b8a268d0c50685e1d2c87477b20f4b31fdff3f990af117b0943d16d0b6e2c197e8e3732876d317ef8bdfa1f82afdcd8ad0a1f62ba53653a",
+            Ok(String::from("ghcr.io/kubewarden/secure-policy@sha512:76ffb94a4cfdc6663b8a268d0c50685e1d2c87477b20f4b31fdff3f990af117b0943d16d0b6e2c197e8e3732876d317ef8bdfa1f82afdcd8ad0a1f62ba53653a")),
+        ),
+        // Error because invalid digest
+        case(
+            "ghcr.io/kubewarden/secure-policy:latest",
+            "https://ghcr.io/v2/kubewarden/secure-policy/manifests/sha256:XYZ4569c3daee67abeaa64192fb53895d0edb2d44fa6e1d9d4c5d3f8ece09f6e",
+            Err(anyhow!("boom")),
+        ),
+        // Error because of shorter digest
+        case(
+            "ghcr.io/kubewarden/secure-policy:latest",
+            "https://ghcr.io/v2/kubewarden/secure-policy/manifests/sha256:72b4569c",
+            Err(anyhow!("boom")),
+        ),
+        // Error because unknown algorithm
+        case(
+            "ghcr.io/kubewarden/secure-policy:latest",
+            "https://ghcr.io/v2/kubewarden/secure-policy/manifests/sha384:72b4569c3daee67abeaa64192fb53895d0edb2d44fa6e1d9d4c5d3f8ece09f6e",
+            Err(anyhow!("boom")),
+        ),
+        // Error because invalid url format
+        case(
+            "ghcr.io/kubewarden/secure-policy:latest",
+            "not an url",
+            Err(anyhow!("boom")),
+        )
+    )]
+    fn test_extract_manifest_digest(
+        image_ref: &str,
+        manifest_url: &str,
+        immutable_ref: Result<String>,
+    ) {
+        let actual = build_immutable_ref(image_ref, manifest_url);
+        match immutable_ref {
+            Err(_) => assert!(actual.is_err()),
+            Ok(r) => assert_eq!(r, actual.unwrap()),
+        }
     }
 }


### PR DESCRIPTION
Change the API of `Registry::push` to return a value inside of its `Result` response.

The method now returns the immutable reference of the policy that has been pushed.

This information is important, because it allows kwctl users to use cosign (from Sigstore) to sign the **actual** policy that has just been pushed to the repo.

Signing policies by tag is not secure, there could be race conditions or attacks that could lead the user to sign a different content. Signing by immutable ref is not affected by these issues.

Because of this API change, the version of this crate will deserve a minor version bump: `0.3.x` -> `0.4.0`
