### PR TITLE
Windows path fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,12 @@ base64 = "0.13.0"
 directories = "4.0.1"
 lazy_static = "1.4.0"
 oci-distribution = { git = "https://github.com/kubewarden/oci-distribution", branch = "not-yet-merged-patches", default-features = false, features =  ["rustls-tls"] }
+path-slash = "0.1.4"
 regex = "1.5.4"
 reqwest = { version = "0.11.3", default-features = false, features = ["rustls-tls"] }
 rustls = "0.19.1"
-serde_json = "1.0.64"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.64"
 serde_yaml = "0.8.15"
 sha2 = "0.10.1"
 sigstore = { git = "https://github.com/sigstore/sigstore-rs", default-features = false, features = ["rustls-tls"], rev = "35fcc0f0a643c42989d301d6940add98f6ca6b6e" }

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -280,7 +280,7 @@ impl PolicyFetcher for Registry {
     }
 }
 
-/// Buidls an immutable OCI reference for the given image
+/// Builds an immutable OCI reference for the given image
 ///
 /// * `image ref`: the mutable image reference. For example: `ghcr.io/kubewarden/secure-policy:latest`
 /// * `manifest_url`: the URL of the manifest, as returned when doing a push operation. For example

--- a/tests/parse_docker_config_json.rs
+++ b/tests/parse_docker_config_json.rs
@@ -63,3 +63,13 @@ fn parses_with_invalid_username_password() {
         }
     )
 }
+
+#[test]
+fn parses_with_missing_auth() {
+    assert_eq!(
+        docker_config("auths-not-present.json"),
+        DockerConfig {
+            auths: HashMap::new(),
+        }
+    )
+}

--- a/tests/test_data/auths-not-present.json
+++ b/tests/test_data/auths-not-present.json
@@ -1,0 +1,5 @@
+{
+  "HttpHeaders": {
+    "User-Agent": "Docker-Client/19.03.15 (linux)"
+  }
+}


### PR DESCRIPTION
Fixes: https://github.com/kubewarden/kwctl/issues/105
Fixes: https://github.com/kubewarden/kwctl/issues/109

Fix policy store path handling in Windows:

- Replace colons (illegal character name for paths) with a fake colon. This allows us to not do anything special for Windows in terms of policy store structure.
- Always use forward slashes for URL's