### PR TITLE
Split patchlevel version bumps and minor/major

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,14 @@ version: 2
 updates:
 - package-ecosystem: cargo
   directory: "/"
+  ignore:
+  # Given dependabot opens a PR per dependency at this time, ignore
+  # patch level updates because of the noise they create. Renovatebot
+  # will take care of creating PR's that bump all patchlevel versions
+  # of all dependencies in a single PR. For minor and major releases
+  # of dependencies we are happy having a PR per dependency.
+  - dependency-name: "*"
+    update-types: ["version-update:semver-patch"]
   schedule:
     interval: daily
     time: "13:00"

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,12 @@
+{
+  "extends": [
+    "config:base",
+    "schedule:earlyMondays"
+  ],
+  "labels": ["dependencies"],
+  "lockFileMaintenance": { "enabled": true },
+  "major": { "enabled": false },
+  "minor": { "enabled": false },
+  "patch": { "enabled": true },
+  "rebaseWhen": "behind-base-branch"
+}


### PR DESCRIPTION
Supersedes: https://github.com/kubewarden/policy-fetcher/pull/46

`dependabot` will take care of bumping minor and major versions in separate PR's per dependency.

`renovatebot` will take care of bumping all patchlevel versions in a single PR for all dependencies.