### PR TITLE
Add verification algorithm tests, and fix failures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.79"
 serde_yaml = "0.8.23"
 sha2 = "0.10.2"
-sigstore = { git = "https://github.com/sigstore/sigstore-rs", default-features = false, features = ["rustls-tls"], rev = "1ee44b396872127f57eaa3038f06bc58ad61f8e6" }
+sigstore = { git = "https://github.com/sigstore/sigstore-rs", default-features = false, features = ["rustls-tls"], rev = "5ae927a652db6076cb9d98b8e3fd8f5baadf3308" }
 tracing = "0.1.31"
 url = { version = "2.2.2", features = ["serde"] }
 walkdir = "2"

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -221,7 +221,7 @@ impl Registry {
                     )],
                     digest: None,
                 },
-                &b"{}".to_vec(),
+                b"{}".as_ref(),
                 manifest::WASM_CONFIG_MEDIA_TYPE,
                 &registry_auth,
                 None,

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -104,9 +104,9 @@ impl TryFrom<RawCertificate> for Certificate {
     type Error = anyhow::Error;
 
     fn try_from(raw_certificate: RawCertificate) -> Result<Certificate> {
-        if reqwest::Certificate::from_pem(&raw_certificate.0.as_bytes().to_vec()).is_ok() {
+        if reqwest::Certificate::from_pem(raw_certificate.0.as_bytes()).is_ok() {
             Ok(Certificate::Pem(raw_certificate.0.as_bytes().to_vec()))
-        } else if reqwest::Certificate::from_der(&raw_certificate.0.as_bytes().to_vec()).is_ok() {
+        } else if reqwest::Certificate::from_der(raw_certificate.0.as_bytes()).is_ok() {
             Ok(Certificate::Der(raw_certificate.0.as_bytes().to_vec()))
         } else {
             Err(anyhow!(
@@ -145,13 +145,12 @@ impl From<Sources> for oci_distribution::client::ClientConfig {
             .source_authorities
             .0
             .iter()
-            .map(|(_, certs)| {
+            .flat_map(|(_, certs)| {
                 certs
                     .iter()
                     .map(|c| c.into())
                     .collect::<Vec<oci_distribution::client::Certificate>>()
             })
-            .flatten()
             .collect();
 
         oci_distribution::client::ClientConfig {
@@ -176,13 +175,12 @@ impl From<Sources> for sigstore::registry::ClientConfig {
             .source_authorities
             .0
             .iter()
-            .map(|(_, certs)| {
+            .flat_map(|(_, certs)| {
                 certs
                     .iter()
                     .map(|c| c.into())
                     .collect::<Vec<sigstore::registry::Certificate>>()
             })
-            .flatten()
             .collect();
 
         sigstore::registry::ClientConfig {

--- a/src/verify/config.rs
+++ b/src/verify/config.rs
@@ -114,6 +114,11 @@ where
 pub fn read_verification_file(path: &Path) -> Result<VerificationSettings> {
     let settings_file = File::open(path)?;
     let vs: VerificationSettings = serde_yaml::from_reader(&settings_file)?;
+    if vs.all_of.is_none() && vs.any_of.is_none() {
+        return Err(anyhow!(
+            "config is missing signatures in both allOf and anyOff list"
+        ));
+    }
     Ok(vs)
 }
 

--- a/src/verify/config.rs
+++ b/src/verify/config.rs
@@ -11,7 +11,7 @@ use crate::verify::verification_constraints;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct VerificationSettings {
+pub struct VerificationConfig {
     pub api_version: String,
     pub all_of: Option<Vec<Signature>>,
     pub any_of: Option<AnyOf>,
@@ -112,15 +112,15 @@ where
     Ok(url)
 }
 
-pub fn read_verification_file(path: &Path) -> Result<VerificationSettings> {
-    let settings_file = File::open(path)?;
-    let vs: VerificationSettings = serde_yaml::from_reader(&settings_file)?;
-    if vs.all_of.is_none() && vs.any_of.is_none() {
+pub fn read_verification_file(path: &Path) -> Result<VerificationConfig> {
+    let config_file = File::open(path)?;
+    let config: VerificationConfig = serde_yaml::from_reader(&config_file)?;
+    if config.all_of.is_none() && config.any_of.is_none() {
         return Err(anyhow!(
             "config is missing signatures in both allOf and anyOff list"
         ));
     }
-    Ok(vs)
+    Ok(config)
 }
 
 #[cfg(test)]
@@ -140,7 +140,7 @@ mod tests {
         #subject:
         #   urlPrefix: https://github.com/kubewarden/
     "#;
-        let _vs: VerificationSettings = serde_yaml::from_str(config).unwrap();
+        let _vs: VerificationConfig = serde_yaml::from_str(config).unwrap();
     }
 
     #[test]
@@ -159,7 +159,7 @@ mod tests {
            urlPrefix: https://github.com/kubewarden
     "#;
 
-        let vs: VerificationSettings = serde_yaml::from_str(config).unwrap();
+        let vs: VerificationConfig = serde_yaml::from_str(config).unwrap();
         let signatures: Vec<Signature> = vec![
             Signature::GenericIssuer {
                     issuer: "https://token.actions.githubusercontent.com".to_string(),
@@ -172,7 +172,7 @@ mod tests {
                 annotations: None,
             }
         ];
-        let expected: VerificationSettings = VerificationSettings {
+        let expected: VerificationConfig = VerificationConfig {
             api_version: "v1".to_string(),
             all_of: Some(signatures),
             any_of: None,
@@ -195,7 +195,7 @@ mod tests {
         subject:
            urlPrefix: https://github.com/kubewarden/ # should deserialize path to kubewarden/
     "#;
-        let vs: VerificationSettings = serde_yaml::from_str(config).unwrap();
+        let vs: VerificationConfig = serde_yaml::from_str(config).unwrap();
         let signatures: Vec<Signature> = vec![
             Signature::GenericIssuer {
                 issuer: "https://token.actions.githubusercontent.com".to_string(),
@@ -208,7 +208,7 @@ mod tests {
                 annotations: None,
             },
         ];
-        let expected: VerificationSettings = VerificationSettings {
+        let expected: VerificationConfig = VerificationConfig {
             api_version: "v1".to_string(),
             all_of: Some(signatures),
             any_of: None,

--- a/src/verify/config.rs
+++ b/src/verify/config.rs
@@ -53,11 +53,12 @@ impl Signature {
     pub fn verifier(&self) -> Result<Box<dyn VerificationConstraint>> {
         match self {
             Signature::PubKey {
-                owner: _,
+                owner,
                 key,
                 annotations,
             } => {
                 let vc = verification_constraints::PublicKeyAndAnnotationsVerifier::new(
+                    owner.as_ref().map(|r| r.as_str()),
                     key,
                     SignatureDigestAlgorithm::default(),
                     annotations.as_ref(),

--- a/src/verify/config.rs
+++ b/src/verify/config.rs
@@ -154,22 +154,21 @@ mod tests {
     "#;
 
         let vs: VerificationSettings = serde_yaml::from_str(config).unwrap();
-        let mut signatures: Vec<Signature> = Vec::new();
-        signatures.push(
-                Signature::GenericIssuer {
-                        issuer: "https://token.actions.githubusercontent.com".to_string(),
-                        subject: Subject::Equal("https://github.com/kubewarden/policy-secure-pod-images/.github/workflows/release.yml@refs/heads/main".to_string()),
-                        annotations: None
-                    }
-            );
-        signatures.push(Signature::GenericIssuer {
-            issuer: "https://token.actions.githubusercontent.com".to_string(),
-            subject: Subject::UrlPrefix(Url::parse("https://github.com/kubewarden/").unwrap()),
-            annotations: None,
-        });
+        let signatures: Vec<Signature> = vec![
+            Signature::GenericIssuer {
+                    issuer: "https://token.actions.githubusercontent.com".to_string(),
+                    subject: Subject::Equal("https://github.com/kubewarden/policy-secure-pod-images/.github/workflows/release.yml@refs/heads/main".to_string()),
+                    annotations: None
+                },
+            Signature::GenericIssuer {
+                issuer: "https://token.actions.githubusercontent.com".to_string(),
+                subject: Subject::UrlPrefix(Url::parse("https://github.com/kubewarden/").unwrap()),
+                annotations: None,
+            }
+        ];
         let expected: VerificationSettings = VerificationSettings {
             api_version: "v1".to_string(),
-            all_of: Some(signatures.clone()),
+            all_of: Some(signatures),
             any_of: None,
         };
         assert_eq!(vs, expected);
@@ -191,20 +190,21 @@ mod tests {
            urlPrefix: https://github.com/kubewarden/ # should deserialize path to kubewarden/
     "#;
         let vs: VerificationSettings = serde_yaml::from_str(config).unwrap();
-        let mut signatures: Vec<Signature> = Vec::new();
-        signatures.push(Signature::GenericIssuer {
-            issuer: "https://token.actions.githubusercontent.com".to_string(),
-            subject: Subject::UrlPrefix(Url::parse("https://github.com/kubewarden/").unwrap()),
-            annotations: None,
-        });
-        signatures.push(Signature::GenericIssuer {
-            issuer: "https://yourdomain.com/oauth2".to_string(),
-            subject: Subject::UrlPrefix(Url::parse("https://github.com/kubewarden/").unwrap()),
-            annotations: None,
-        });
+        let signatures: Vec<Signature> = vec![
+            Signature::GenericIssuer {
+                issuer: "https://token.actions.githubusercontent.com".to_string(),
+                subject: Subject::UrlPrefix(Url::parse("https://github.com/kubewarden/").unwrap()),
+                annotations: None,
+            },
+            Signature::GenericIssuer {
+                issuer: "https://yourdomain.com/oauth2".to_string(),
+                subject: Subject::UrlPrefix(Url::parse("https://github.com/kubewarden/").unwrap()),
+                annotations: None,
+            },
+        ];
         let expected: VerificationSettings = VerificationSettings {
             api_version: "v1".to_string(),
-            all_of: Some(signatures.clone()),
+            all_of: Some(signatures),
             any_of: None,
         };
         assert_eq!(vs, expected);

--- a/src/verify/mod.rs
+++ b/src/verify/mod.rs
@@ -171,9 +171,11 @@ impl Verifier {
             .manifest(&image_immutable_ref, self.sources.as_ref())
             .await?;
 
-        let digests: Vec<String>;
-        if let oci_distribution::manifest::OciManifest::Image(ref image) = manifest {
-            digests = image
+        let digests: Vec<String> = if let oci_distribution::manifest::OciManifest::Image(
+            ref image,
+        ) = manifest
+        {
+            image
                 .layers
                 .iter()
                 .filter_map(|layer| match layer.media_type.as_str() {
@@ -183,7 +185,7 @@ impl Verifier {
                 .collect()
         } else {
             unreachable!("Expected Image, found ImageIndex manifest. This cannot happen, as oci clientConfig.platform_resolver is None and we will error earlier");
-        }
+        };
 
         if digests.len() != 1 {
             error!(manifest = ?manifest, "The manifest is expected to have one WASM layer");

--- a/src/verify/verification_constraints.rs
+++ b/src/verify/verification_constraints.rs
@@ -51,11 +51,8 @@ impl VerificationConstraint for PublicKeyAndAnnotationsVerifier {
         } else {
             self.pub_key_verifier.verify(sl)?
         };
-        if !outcome && self.owner.is_some() {
-            info!(
-                "pubkey not satisfied for owner {}",
-                self.owner.as_ref().unwrap()
-            );
+        if !outcome {
+            info!(owner = ?&self.owner, "pubkey not satisfied");
         }
         Ok(outcome)
     }


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Relates to https://github.com/kubewarden/policy-server/issues/142.

Depends on https://github.com/sigstore/sigstore-rs/pull/40.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Added tests as part of unit tests, run with `make test`.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

Refactored the verification algorithm, which filters with contraints, into its own function.

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

Another option could have been to add integration tests under `tests/`. But that entails mocking the registry and image, with its layers, and the codepath under test wouldn't have grown much, as sigstore-rs has its own tests.
