### PR TITLE
verifier: improve how fulcio and rekor data is found

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.79"
 serde_yaml = "0.8.23"
 sha2 = "0.10.2"
-sigstore = { git = "https://github.com/sigstore/sigstore-rs", default-features = false, features = ["rustls-tls"], rev = "5ae927a652db6076cb9d98b8e3fd8f5baadf3308" }
+sigstore = { git = "https://github.com/sigstore/sigstore-rs", default-features = false, features = ["rustls-tls"], rev = "3954129ff0fc91beb8b8a6568ecb09e8c2d19392" }
 tracing = "0.1.32"
 url = { version = "2.2.2", features = ["serde"] }
 walkdir = "2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,10 @@ use std::path::{Path, PathBuf};
 use tracing::debug;
 use url::ParseError;
 
+// re-export for usage by kwctl, policy-server, policy-evaluator,...
+pub use oci_distribution;
+pub use sigstore;
+
 #[derive(Debug)]
 pub enum PullDestination {
     MainStore,


### PR DESCRIPTION
Allow consumers of the library to either provide fulcio and rekor data manually, or by fetching it from a TUF repository.

The crate is now re-exposing the `sigstore` and the `oci-distribution` crates. This is required to simplify dependency management, because these are 2 crates that can be used by consumers of this library.
