### PR TITLE
feat: Print debug messages for satisfied constraints

### DIFF
--- a/src/verify/mod.rs
+++ b/src/verify/mod.rs
@@ -280,7 +280,18 @@ fn verify_signatures_against_config(
             .filter(|signature| match signature.verifier() {
                 Ok(verifier) => {
                     let constraints = [verifier];
-                    cosign::verify_constraints(trusted_layers, constraints.iter()).is_err()
+                    let is_satisfied =
+                        cosign::verify_constraints(trusted_layers, constraints.iter());
+                    match is_satisfied {
+                        Ok(_) => {
+                            debug!(
+                                "Constraint satisfied:\n{}",
+                                &serde_yaml::to_string(signature).unwrap()
+                            );
+                            false
+                        }
+                        Err(_) => true, //filter into unsatisfied_signatures
+                    }
                 }
                 Err(error) => {
                     info!(?error, ?signature, "Cannot create verifier for signature");


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Example:

```console
$ kwctl -v verify registry://ghcr.io/kubewarden/policies/pod-privileged:v0.1.10

(...)
2022-03-16T11:15:53.110176Z DEBUG policy_fetcher::verify: Constraint satisfied:
---
kind: githubAction
owner: kubewarden
repo: ~
annotations: ~

2022-03-16T11:15:53.110271Z DEBUG policy_fetcher::verify: Policy successfully verified policy="registry://ghcr.io/kubewarden/policies/pod-privileged:v0.1.10"
2022-03-16T11:15:53.110362Z  INFO kwctl::verify: Policy successfully verified
2022-03-16T11:15:53.110761Z DEBUG Connection{peer=Client}: h2::codec::framed_write: send frame=GoAway { error_code: NO_ERROR, last_stream_id: StreamId(0) }
2022-03-16T11:15:53.111023Z DEBUG Connection{peer=Client}: h2::proto::connection: Connection::poll; connection error error=GoAway(b"", NO_ERROR, Library)
2022-03-16T11:15:53.111393Z DEBUG Connection{peer=Client}: rustls::conn: Sending warning alert CloseNotify
```


## Test
Manually, consuming in kwctl and doing `kwctl -v verify registry://ghcr.io/kubewarden/policies/pod-privileged:v0.1.10` with default verification settings.


