### PR TITLE
feat: Add pub `verify_pub_keys()`, `verify_keyless_exact_match()`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-fetcher"
-version = "0.6.1"
+version = "0.7.0"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>",
@@ -32,7 +32,7 @@ tracing = "0.1.34"
 url = { version = "2.2.2", features = ["serde"] }
 walkdir = "2"
 rayon = "1.5.2"
-kubewarden-policy-sdk = { git = "https://github.com/raulcabello/policy-sdk-rust", branch = "sigstore_container_verification" }
+kubewarden-policy-sdk = { git = "https://github.com/kubewarden/policy-sdk-rust", tag = "v0.4.0" }
 
 [dev-dependencies]
 rstest = "0.12.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ tracing = "0.1.34"
 url = { version = "2.2.2", features = ["serde"] }
 walkdir = "2"
 rayon = "1.5.2"
+kubewarden-policy-sdk = { git = "https://github.com/raulcabello/policy-sdk-rust", branch = "sigstore_container_verification" }
 
 [dev-dependencies]
 rstest = "0.12.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.79"
 serde_yaml = "0.8.23"
 sha2 = "0.10.2"
-sigstore = { git = "https://github.com/sigstore/sigstore-rs", default-features = false, features = ["rustls-tls"], rev = "3954129ff0fc91beb8b8a6568ecb09e8c2d19392" }
+sigstore = { git = "https://github.com/sigstore/sigstore-rs", default-features = false, features = ["rustls-tls"], rev = "cb3606a9d3d05a5e318bb3837f48c560c01cc2ff" }
 tracing = "0.1.34"
 url = { version = "2.2.2", features = ["serde"] }
 walkdir = "2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,17 +216,17 @@ mod tests {
 
     fn read_fixture(filename: &Path) -> Vec<u8> {
         let test_data_file = std::env::current_dir()
-            .expect(&format!(
-                "[test setup error] could not read the current directory"
-            ))
+            .unwrap_or_else(|_| panic!("[test setup error] could not read the current directory"))
             .join("tests")
             .join("test_data")
             .join(filename);
 
-        fs::read(&test_data_file).expect(&format!(
-            "[test setup error] could not read file {:?}",
-            &test_data_file
-        ))
+        fs::read(&test_data_file).unwrap_or_else(|_| {
+            panic!(
+                "[test setup error] could not read file {:?}",
+                &test_data_file
+            )
+        })
     }
 
     fn store_path(path: &str) -> PathBuf {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ use tracing::debug;
 use url::ParseError;
 
 // re-export for usage by kwctl, policy-server, policy-evaluator,...
+pub use kubewarden_policy_sdk;
 pub use oci_distribution;
 pub use sigstore;
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -282,23 +282,21 @@ mod tests {
     fn keep_policy_full_path_unix() {
         assert_eq!(
             retrieve_policy_store_path(
-                PathBuf::from("/registry/example.com:1234/some/path").into_iter()
+                PathBuf::from("/registry/example.com:1234/some/path").iter()
             )
             .unwrap(),
             "/registry/example.com:1234/some/path".to_string()
         );
         assert_eq!(
             retrieve_policy_store_path(
-                PathBuf::from("/registry/example.com:1234/some/path/to/policy:tag").into_iter()
+                PathBuf::from("/registry/example.com:1234/some/path/to/policy:tag").iter()
             )
             .unwrap(),
             "/registry/example.com:1234/some/path/to/policy:tag".to_string()
         );
         assert_eq!(
-            retrieve_policy_store_path(
-                PathBuf::from("/https/example.com:1234/some/path").into_iter()
-            )
-            .unwrap(),
+            retrieve_policy_store_path(PathBuf::from("/https/example.com:1234/some/path").iter())
+                .unwrap(),
             "/https/example.com:1234/some/path".to_string()
         );
     }
@@ -324,7 +322,7 @@ mod tests {
                         "path".as_bytes(),
                         base64::URL_SAFE_NO_PAD
                     ))
-                    .into_iter()
+                    .iter()
             )?,
             "/registry/example.com:1234/some/path".to_string()
         );
@@ -355,7 +353,7 @@ mod tests {
                         "policy:tag".as_bytes(),
                         base64::URL_SAFE_NO_PAD
                     ))
-                    .into_iter()
+                    .iter()
             )?,
             "/registry/example.com:1234/some/path/to/policy:tag".to_string()
         );
@@ -378,7 +376,7 @@ mod tests {
                         "path".as_bytes(),
                         base64::URL_SAFE_NO_PAD
                     ))
-                    .into_iter()
+                    .iter()
             )?,
             "/https/example.com:1234/some/path".to_string()
         );

--- a/src/verify/mod.rs
+++ b/src/verify/mod.rs
@@ -99,6 +99,17 @@ impl Verifier {
         })
     }
 
+    /// Verifies the given policy using the LatestVerificationConfig provided by
+    /// the user.
+    ///
+    /// In case of success, returns the manifest digest of the verified policy.
+    ///
+    /// Note well: this method doesn't compare the checksum of a possible local
+    /// file with the one inside of the signed (and verified) manifest, as that
+    /// can only be done with certainty after pulling the policy.
+    ///
+    /// Note well: right now, verification can be done only against policies
+    /// that are stored inside of OCI registries.
     pub async fn verify(
         &mut self,
         image_url: &str,

--- a/src/verify/mod.rs
+++ b/src/verify/mod.rs
@@ -88,6 +88,8 @@ impl Verifier {
             }
         }
 
+        cosign_client_builder = cosign_client_builder.enable_registry_caching();
+
         let cosign_client = cosign_client_builder
             .build()
             .map_err(|e| anyhow!("could not build a cosign client: {}", e))?;

--- a/src/verify/mod.rs
+++ b/src/verify/mod.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 
 use crate::verify::config::Subject;
 use oci_distribution::Reference;
+use sigstore::errors::SigstoreError;
 use std::convert::TryFrom;
 use std::{convert::TryInto, str::FromStr};
 use tracing::{debug, error, info};
@@ -257,10 +258,19 @@ impl Verifier {
         let (cosign_signature_image, source_image_digest) =
             self.cosign_client.triangulate(image_name, &auth).await?;
 
-        let trusted_layers = self
+        let trusted_layers = match self
             .cosign_client
             .trusted_signature_layers(&auth, &source_image_digest, &cosign_signature_image)
-            .await?;
+            .await
+        {
+            Ok(trusted_layers) => trusted_layers,
+            Err(SigstoreError::RegistryPullManifestError { .. }) => {
+                return Err(anyhow!("No signatures found for image {}", image_name));
+            }
+            Err(e) => {
+                return Err(anyhow!("{}", e));
+            }
+        };
 
         use rayon::prelude::*;
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -3,17 +3,17 @@ use std::{fs::read_to_string, path::Path};
 #[allow(dead_code)]
 pub(crate) fn test_data(filename: &Path) -> String {
     let test_data_file = std::env::current_dir()
-        .expect(&format!(
-            "[test setup error] could not read the current directory"
-        ))
+        .unwrap_or_else(|_| panic!("[test setup error] could not read the current directory"))
         .join("tests")
         .join("test_data")
         .join(filename);
 
-    read_to_string(&test_data_file).expect(&format!(
-        "[test setup error] could not read file {:?}",
-        &test_data_file
-    ))
+    read_to_string(&test_data_file).unwrap_or_else(|_| {
+        panic!(
+            "[test setup error] could not read file {:?}",
+            &test_data_file
+        )
+    })
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/policy-server/issues/99
Supersedes https://github.com/kubewarden/policy-fetcher/pull/77

- Add pub functions `verify_pub_keys()`, `verify_keyless_exact_match()`. These are shims that translate to an interim `VerificationConfig` and call `verify()`, so only 1 codepath exists, no need for tests.
- re-export kubewarden_policy_sdk through policy-fetcher for consumption.
- Minor refactors and error checking.

I suggest "files-changed" review, given the hard refactors.

TODO: depends on rust sdk work.