### PR TITLE
feat: add more descriptive error when an image does not have signatures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-fetcher"
-version = "0.7.1"
+version = "0.7.2"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>",


### PR DESCRIPTION
Show a more descriptive error when an image does not have signatures. This is the error a user see when an image is not signed:

```
Cannot pull manifest of ghcr.io/kubewarden/test-verify-image-signatures:sha256-706446e9c6667c0880d5da3f39c09a6c7d2114f5a5d6b74a2fafd24ae30d2078.sig: OCI API error: manifest unknown on https://ghcr.io/v2/kubewarden/test-verify-image-signatures/manifests/sha256-706446e9c6667c0880d5da3f39c09a6c7d2114f5a5d6b74a2fafd24ae30d2078.sig
```

With this improvement, the user will see:

```
 signatures can't be fetched for image: ghcr.io/kubewarden/test-verify-image-signatures:unsigned
```

Fix #82 