### PR TITLE
Remove the dependency on policy-fetcher SDK

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-fetcher"
-version = "0.7.0"
+version = "0.7.1"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>",
@@ -32,7 +32,6 @@ tracing = "0.1.34"
 url = { version = "2.2.2", features = ["serde"] }
 walkdir = "2"
 rayon = "1.5.2"
-kubewarden-policy-sdk = { git = "https://github.com/kubewarden/policy-sdk-rust", tag = "v0.4.0" }
 
 [dev-dependencies]
 rstest = "0.12.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,6 @@ use tracing::debug;
 use url::ParseError;
 
 // re-export for usage by kwctl, policy-server, policy-evaluator,...
-pub use kubewarden_policy_sdk;
 pub use oci_distribution;
 pub use sigstore;
 


### PR DESCRIPTION
The Rust SDK dependency is no longer needed, we should get rid of it.

This was a leftover from one of the previous iterations of the Sigstore integration.
