### PR TITLE
GitHub actions extensions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-fetcher"
-version = "0.7.3"
+version = "0.7.4"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.81"
 serde_yaml = "0.8.24"
 sha2 = "0.10.2"
-sigstore = { git = "https://github.com/sigstore/sigstore-rs", default-features = false, features = ["rustls-tls"], rev = "cb3606a9d3d05a5e318bb3837f48c560c01cc2ff" }
+sigstore = { git = "https://github.com/sigstore/sigstore-rs", default-features = false, features = ["rustls-tls"], rev = "a817a40534af55eda5750a46104e6e9f40b31d7a" }
 tracing = "0.1.34"
 url = { version = "2.2.2", features = ["serde"] }
 walkdir = "2"

--- a/src/verify/mod.rs
+++ b/src/verify/mod.rs
@@ -384,6 +384,11 @@ kvUsh4eKpd1lwkDAzfFDs7yXEExsEkPPuiQJBelDT68n7PDIWB/QEY7mrA==
             verification_key,
             issuer,
             subject,
+            github_workflow_trigger: None,
+            github_workflow_sha: None,
+            github_workflow_name: None,
+            github_workflow_repository: None,
+            github_workflow_ref: None,
         });
 
         SignatureLayer {

--- a/src/verify/verification_constraints.rs
+++ b/src/verify/verification_constraints.rs
@@ -242,10 +242,8 @@ impl VerificationConstraint for GitHubVerifier {
             SigstoreError::VerificationConstraintError(format!("The certificate subject url doesn't seem a GitHub valid one, despite the issuer being the GitHub Action one: {}", signature_subject)))?;
 
         // the certificate github_workflow_extension must be there and correctly constructed
-        let github_workflow_repository =  match &certificate_signature.github_workflow_repository {
-            Some(workflow_repository) => workflow_repository,
-            None => return Err(SigstoreError::VerificationConstraintError(format!("The certificate is missing the github_workflow_repository extension despite being a GitHub Action one: {}", signature_subject))),
-        };
+        let github_workflow_repository = certificate_signature.github_workflow_repository.as_ref()
+            .ok_or_else(|| SigstoreError::VerificationConstraintError("The certificate is missing the github_workflow_repository extension despite being a GitHub Action one".to_string()))?;
 
         let signature_repo = GitHubRepo::try_from(format!("https://github.com/{}", github_workflow_repository).as_str())
             .map_err(|_|


### PR DESCRIPTION
## Description

On GithubVerifier, validate using the `github_workflow_repository`
extension in signature certificate, instead of the `subject`.

The `github_workflow_repository` extension contains the repo of the GH
Action workflow that was triggered, not the one that was called. For
example in the case of consuming a reusable workflow
`octocat/reusable-workflows-repo` in `octocat/example`,
`github_workflow_repository` contains `octocat/example`.

This protects against incorrectly validating signatures that have been
performed in reusable workflows.

## Test

Passing unit tests, also tested locally with a policy-server consuming this, and public policies.

