### PR TITLE
bump sigstore-rs to v0.3.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-fetcher"
-version = "0.7.7"
+version = "0.7.8"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>",
@@ -27,7 +27,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.81"
 serde_yaml = "0.8.24"
 sha2 = "0.10.2"
-sigstore = { git = "https://github.com/sigstore/sigstore-rs", default-features = false, features = ["rustls-tls"], rev = "v0.3.1" }
+sigstore = { git = "https://github.com/sigstore/sigstore-rs", default-features = false, features = ["rustls-tls"], rev = "v0.3.2" }
 tracing = "0.1.35"
 url = { version = "2.2.2", features = ["serde"] }
 walkdir = "2"


### PR DESCRIPTION
Use latest sigstore-rs to fix https://github.com/kubewarden/verify-image-signatures/issues/20
