### PR TITLE
Consume sigstorers from crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.82"
 serde_yaml = "0.8.24"
 sha2 = "0.10.2"
-sigstore = { git = "https://github.com/sigstore/sigstore-rs", default-features = false, features = ["rustls-tls"], rev = "v0.3.2" }
+sigstore = { version = "0.3.2", default-features = false, features = ["rustls-tls"] }
 tracing = "0.1.35"
 url = { version = "2.2.2", features = ["serde"] }
 walkdir = "2"


### PR DESCRIPTION
This speeds up the build because the git repository doesn't have to be cloned/updated locally.
