### PR TITLE
Update to latest release of slash-path crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ base64 = "0.13.0"
 directories = "4.0.1"
 lazy_static = "1.4.0"
 oci-distribution = { version = "0.9.2", default-features = false, features =  ["rustls-tls"] }
-path-slash = "0.1.5"
+path-slash = "0.2.0"
 regex = "1.5.6"
 reqwest = { version = "0.11.11", default-features = false, features = ["rustls-tls"] }
 rustls = "0.20.6"

--- a/src/store.rs
+++ b/src/store.rs
@@ -259,7 +259,8 @@ fn transform_policy_store_path<'a>(
             }
         })
         .map_err(|_| anyhow!("cannot compute policy path"))?
-        .to_slash_lossy())
+        .to_slash_lossy()
+        .to_string())
 }
 
 impl Default for Store {


### PR DESCRIPTION
Fix the compilation error introduced by the API changes.

Supersedes https://github.com/kubewarden/policy-fetcher/pull/102

