### PR TITLE
Allow fulcio and rekor data to be None

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-fetcher"
-version = "0.7.8"
+version = "0.7.9"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>",


### PR DESCRIPTION
Do not fail when Fulcio and Rekor data are None. The Sigstore integration will still work, but it will provide some false negatives.

False netative means: a perfectly valid signature produced with keyless mode will be reported as non valid.

This is currently required to handle the case when the upstream TUF repository of Sigstore is broken.
