### PR TITLE
Upgrade to latest serde_yaml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ reqwest = { version = "0.11.11", default-features = false, features = ["rustls-t
 rustls = "0.20.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.82"
-serde_yaml = "0.8.26"
+serde_yaml = "0.9"
 sha2 = "0.10.2"
 sigstore = { version = "0.3.2", default-features = false, features = ["rustls-tls"] }
 tracing = "0.1.36"

--- a/src/verify/mod.rs
+++ b/src/verify/mod.rs
@@ -488,12 +488,10 @@ kvUsh4eKpd1lwkDAzfFDs7yXEExsEkPPuiQJBelDT68n7PDIWB/QEY7mrA==
         assert!(error.is_err());
         let expected_msg = r#"Image verification failed: missing signatures
 The following constraints were not satisfied:
----
 kind: genericIssuer
-issuer: "https://github.com/login/oauth"
-subject:
-  equal: user1@provider.com
-annotations: ~
+issuer: https://github.com/login/oauth
+subject: !equal user1@provider.com
+annotations: null
 "#;
         assert_eq!(error.unwrap_err().to_string(), expected_msg);
     }
@@ -521,12 +519,10 @@ annotations: ~
         assert!(error.is_err());
         let expected_msg = r#"Image verification failed: missing signatures
 The following constraints were not satisfied:
----
 kind: genericIssuer
-issuer: "https://github.com/login/oauth"
-subject:
-  equal: user3@provider.com
-annotations: ~
+issuer: https://github.com/login/oauth
+subject: !equal user3@provider.com
+annotations: null
 "#;
         assert_eq!(error.unwrap_err().to_string(), expected_msg);
     }
@@ -557,18 +553,14 @@ annotations: ~
         assert!(error.is_err());
         let expected_msg = r#"Image verification failed: minimum number of signatures not reached: needed 2, got 1
 The following constraints were not satisfied:
----
 kind: genericIssuer
-issuer: "https://github.com/login/oauth"
-subject:
-  equal: user2@provider.com
-annotations: ~
----
+issuer: https://github.com/login/oauth
+subject: !equal user2@provider.com
+annotations: null
 kind: genericIssuer
-issuer: "https://github.com/login/oauth"
-subject:
-  equal: user3@provider.com
-annotations: ~
+issuer: https://github.com/login/oauth
+subject: !equal user3@provider.com
+annotations: null
 "#;
         assert_eq!(error.unwrap_err().to_string(), expected_msg);
     }


### PR DESCRIPTION
Upgrade to latest stable release of serde_yaml. This version minor bump breaks the output produced when serializing an object to YAML. Because of that, some unit tests had to be fixed.

If that happens again, we will revisit how the unit tests works to make them more robust.
