### PR TITLE
No docker credential change loglevel to debug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.83"
 serde_yaml = "0.9"
 sha2 = "0.10.2"
-sigstore = { version = "0.3.2", default-features = false, features = ["rustls-tls"] }
+sigstore = { version = "0.3.3", default-features = false, features = ["rustls-tls"] }
 tracing = "0.1.36"
 url = { version = "2.2.2", features = ["serde"] }
 walkdir = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-fetcher"
-version = "0.7.10"
+version = "0.7.11"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>",

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -105,7 +105,7 @@ impl Registry {
                 }
             },
             Err(error) => {
-                warn!(
+                debug!(
                     ?error,
                     %registry,
                     "Couldn't fetch credentials. Using anonymous instead"


### PR DESCRIPTION
don't show a warning message if no credentials were provided as this will be the case if a user is pulling from a public registry