### PR TITLE
update to latest sigstore

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-fetcher"
-version = "0.7.11"
+version = "0.7.12"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.86"
 serde_yaml = "0.9"
 sha2 = "0.10.6"
-sigstore = { version = "0.4.0", default-features = false, features = ["rustls-tls"] }
+sigstore = { version = "0.5", default-features = false, features = ["rustls-tls"] }
 tracing = "0.1.37"
 url = { version = "2.2.2", features = ["serde"] }
 walkdir = "2"

--- a/src/verify/config.rs
+++ b/src/verify/config.rs
@@ -1,8 +1,6 @@
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Deserializer, Serialize};
-use sigstore::{
-    cosign::verification_constraint::VerificationConstraint, crypto::SignatureDigestAlgorithm,
-};
+use sigstore::cosign::verification_constraint::VerificationConstraint;
 use std::boxed::Box;
 use std::{collections::HashMap, fs, path::Path};
 use url::Url;
@@ -89,7 +87,6 @@ impl Signature {
                 let vc = verification_constraints::PublicKeyAndAnnotationsVerifier::new(
                     owner.as_ref().map(|r| r.as_str()),
                     key,
-                    SignatureDigestAlgorithm::default(),
                     annotations.as_ref(),
                 )
                 .map_err(|e| anyhow!("Cannot create public key verifier: {}", e))?;

--- a/src/verify/mod.rs
+++ b/src/verify/mod.rs
@@ -361,11 +361,9 @@ mod tests {
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELKhD7F5OKy77Z582Y6h0u1J3GNA+
 kvUsh4eKpd1lwkDAzfFDs7yXEExsEkPPuiQJBelDT68n7PDIWB/QEY7mrA==
 -----END PUBLIC KEY-----"#;
-        let verification_key = sigstore::crypto::CosignVerificationKey::from_pem(
-            pub_key.as_bytes(),
-            sigstore::crypto::SignatureDigestAlgorithm::default(),
-        )
-        .expect("Cannot create CosignVerificationKey");
+        let verification_key =
+            sigstore::crypto::CosignVerificationKey::try_from_pem(pub_key.as_bytes())
+                .expect("Cannot create CosignVerificationKey");
 
         let raw_data = r#"{"critical":{"identity":{"docker-reference":"registry-testing.svc.lan/kubewarden/disallow-service-nodeport"},"image":{"docker-manifest-digest":"sha256:5f481572d088dc4023afb35fced9530ced3d9b03bf7299c6f492163cb9f0452e"},"type":"cosign container image signature"},"optional":null}"#;
         let raw_data = raw_data.as_bytes().to_vec();


### PR DESCRIPTION
Upgrade to latest release of sigstore-rs. This is required to fix https://github.com/kubewarden/verify-image-signatures/issues/20

