### PR TITLE
Add policy_path method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-fetcher"
-version = "0.7.13"
+version = "0.7.14"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>",


### PR DESCRIPTION
We need to know the path of a policy without the store prefix for saving policies in a tarball.
This PR adds a new method for this