### PR TITLE
Windows fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-fetcher"
-version = "0.7.14"
+version = "0.7.15"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>",

--- a/src/store.rs
+++ b/src/store.rs
@@ -103,8 +103,8 @@ impl Store {
         })
     }
 
-    fn policy_file_name(url: &Url) -> &str {
-        let filename = url.path().split('/').last().unwrap();
+    fn policy_file_name(url: &Url) -> String {
+        let filename = url.path().split('/').last().unwrap().to_string();
 
         // In Windows we encode the filename with base64, so it can
         // contain special characters like `:` that are not allowed in


### PR DESCRIPTION
Windows release is [failing](https://github.com/kubewarden/kwctl/actions/runs/3463242415/jobs/5783488270) because of the following error:

```
116 |         filename
    |         ^^^^^^^^
    |         expected `&str`, found struct `std::string::String`
    |         help: consider borrowing here: `&filename`
```

This PR returns a `String` in `policy_file_name` method to fix this error

