### PR TITLE
feat: add Policy getters to Store

### DIFF
--- a/src/policy.rs
+++ b/src/policy.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::fmt::Display;
 use std::path::PathBuf;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Policy {
     pub uri: String,
     pub local_path: PathBuf,


### PR DESCRIPTION
## Description

Adds `Store::get_policy_by_uri` and `Store::get_policy_by_sha_prefix`.
The latter takes a partial sha and returns a policy that matches.
Returns error if multiple results are found.
This behavior is similar to the docker cli, see: https://github.com/docker/engine/blob/8955d8da8951695a98eb7e15bead19d402c6eb27/daemon/container.go#L36

## Test

Added integration tests.


## Additional Information

### Tradeoff


