### PR TITLE
fix: list non existing store

### DIFF
--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -123,6 +123,10 @@ impl Store {
     pub fn list(&self) -> Result<Vec<Policy>> {
         let mut policies = Vec::new();
 
+        if !self.root.exists() {
+            return Ok(policies);
+        }
+
         let store_root_path = std::fs::read_dir(self.root.as_path())?;
         for scheme in store_root_path {
             let scheme = scheme?;

--- a/tests/store.rs
+++ b/tests/store.rs
@@ -43,6 +43,15 @@ fn test_list() {
 }
 
 #[test]
+fn test_list_non_existing_store_root() {
+    let store = Store::new(Path::new("./does/not/exist"));
+
+    let list = store.list().expect("failed to list policies");
+
+    assert!(list.is_empty());
+}
+
+#[test]
 fn test_get_policy_by_uri() {
     let store_root = tempdir().unwrap();
 


### PR DESCRIPTION
## Description

In the previous implementation, the `read_dir` error was silenced, so when a store with a non-existing root was listed an empty list was returned. See: https://github.com/kubewarden/policy-fetcher/blob/3f73d90678939b7375f5f4cb2ad76ecdec1dfe2f/src/store.rs#L189
Since we now bubble up any error caused by `read_dir`, this was returning an error if the path did not exist breaking the original behavior.
This was breaking e2e tests on kwctl too.

## Test

Added an integration test for this scenario.

## Additional Information

NOTE: This implementation is probably going to change soon with the Database feature.
