### PR TITLE
chore: do not use Result in tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -391,96 +391,102 @@ mod tests {
     }
 
     #[test]
-    fn local_file_pull_destination_excluding_filename() -> Result<()> {
+    fn local_file_pull_destination_excluding_filename() {
         assert_eq!(
             pull_destination(
-                &Url::parse("https://host.example.com:1234/path/to/policy.wasm")?,
-                &PullDestination::LocalFile(std::env::current_dir()?),
-            )?,
-            (None, std::env::current_dir()?.join("policy.wasm"),),
+                &Url::parse("https://host.example.com:1234/path/to/policy.wasm").unwrap(),
+                &PullDestination::LocalFile(std::env::current_dir().unwrap()),
+            )
+            .expect("pull_destination failed"),
+            (None, std::env::current_dir().unwrap().join("policy.wasm"),),
         );
-        Ok(())
     }
 
     #[test]
-    fn local_file_pull_destination_including_filename() -> Result<()> {
+    fn local_file_pull_destination_including_filename() {
         assert_eq!(
             pull_destination(
-                &Url::parse("https://host.example.com:1234/path/to/policy.wasm")?,
-                &PullDestination::LocalFile(std::env::current_dir()?.join("named-policy.wasm")),
-            )?,
-            (None, std::env::current_dir()?.join("named-policy.wasm"),),
+                &Url::parse("https://host.example.com:1234/path/to/policy.wasm").unwrap(),
+                &PullDestination::LocalFile(
+                    std::env::current_dir().unwrap().join("named-policy.wasm")
+                ),
+            )
+            .expect("pull_destination failed"),
+            (
+                None,
+                std::env::current_dir().unwrap().join("named-policy.wasm"),
+            ),
         );
-        Ok(())
     }
 
     #[test]
-    fn store_pull_destination_from_http_with_port() -> Result<()> {
+    fn store_pull_destination_from_http_with_port() {
         assert_eq!(
             pull_destination(
-                &Url::parse("http://host.example.com:1234/path/to/policy.wasm")?,
+                &Url::parse("http://host.example.com:1234/path/to/policy.wasm").unwrap(),
                 &PullDestination::MainStore,
-            )?,
+            )
+            .expect("pull_destination failed"),
             (
                 Some(Store::default()),
                 store_path("http/host.example.com:1234/path/to/policy.wasm"),
             ),
         );
-        Ok(())
     }
 
     #[test]
-    fn store_pull_destination_from_http() -> Result<()> {
+    fn store_pull_destination_from_http() {
         assert_eq!(
             pull_destination(
-                &Url::parse("http://host.example.com/path/to/policy.wasm")?,
+                &Url::parse("http://host.example.com/path/to/policy.wasm").unwrap(),
                 &PullDestination::MainStore,
-            )?,
+            )
+            .expect("pull_destination failed"),
             (
                 Some(Store::default()),
                 store_path("http/host.example.com/path/to/policy.wasm"),
             ),
         );
-        Ok(())
     }
 
     #[test]
-    fn store_pull_destination_from_https() -> Result<()> {
+    fn store_pull_destination_from_https() {
         assert_eq!(
             pull_destination(
-                &Url::parse("https://host.example.com/path/to/policy.wasm")?,
+                &Url::parse("https://host.example.com/path/to/policy.wasm").unwrap(),
                 &PullDestination::MainStore,
-            )?,
+            )
+            .expect("pull_destination failed"),
             (
                 Some(Store::default()),
                 store_path("https/host.example.com/path/to/policy.wasm"),
             ),
         );
-        Ok(())
     }
 
     #[test]
-    fn store_pull_destination_from_https_with_port() -> Result<()> {
+    fn store_pull_destination_from_https_with_port() {
         assert_eq!(
             pull_destination(
-                &Url::parse("https://host.example.com:1234/path/to/policy.wasm")?,
+                &Url::parse("https://host.example.com:1234/path/to/policy.wasm").unwrap(),
                 &PullDestination::MainStore,
-            )?,
+            )
+            .expect("pull_destination failed"),
             (
                 Some(Store::default()),
                 store_path("https/host.example.com:1234/path/to/policy.wasm"),
             ),
         );
-        Ok(())
     }
 
     #[test]
-    fn store_pull_destination_from_registry() -> Result<()> {
+    fn store_pull_destination_from_registry() {
         assert_eq!(
             pull_destination(
-                &Url::parse("registry://host.example.com/path/to/policy:tag")?,
+                &Url::parse("registry://host.example.com/path/to/policy:tag").unwrap(),
                 &PullDestination::MainStore,
-            )?,
+            )
+            .expect("pull_destination failed"),
             (
                 Some(Store::default()),
                 store_path("registry/host.example.com/path/to/policy:tag"),
@@ -488,30 +494,30 @@ mod tests {
         );
         assert_eq!(
             pull_destination(
-                &Url::parse("registry://host.example.com/policy:tag")?,
+                &Url::parse("registry://host.example.com/policy:tag").unwrap(),
                 &PullDestination::MainStore,
-            )?,
+            )
+            .expect("pull_destination failed"),
             (
                 Some(Store::default()),
                 store_path("registry/host.example.com/policy:tag"),
             ),
         );
-        Ok(())
     }
 
     #[test]
-    fn store_pull_destination_from_registry_with_port() -> Result<()> {
+    fn store_pull_destination_from_registry_with_port() {
         assert_eq!(
             pull_destination(
-                &Url::parse("registry://host.example.com:1234/path/to/policy:tag")?,
+                &Url::parse("registry://host.example.com:1234/path/to/policy:tag").unwrap(),
                 &PullDestination::MainStore,
-            )?,
+            )
+            .expect("pull_destination failed"),
             (
                 Some(Store::default()),
                 store_path("registry/host.example.com:1234/path/to/policy:tag"),
             ),
         );
-        Ok(())
     }
 
     #[rstest]

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -288,11 +288,11 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
     }
 
     #[test]
-    fn test_raw_path_based_source_authority_convertion_into_raw_certificate() -> Result<()> {
-        let mut file = NamedTempFile::new()?;
+    fn test_raw_path_based_source_authority_convertion_into_raw_certificate() {
+        let mut file = NamedTempFile::new().unwrap();
 
         let expected_contents = "hello world";
-        write!(file, "{}", expected_contents)?;
+        write!(file, "{}", expected_contents).unwrap();
 
         let path = file.path();
         let auth = RawSourceAuthority::Path {
@@ -308,8 +308,6 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
                 panic!("Didn't get what I was expecting: {:?}", unexpected);
             }
         }
-
-        Ok(())
     }
 
     #[test]

--- a/src/store/path/windows.rs
+++ b/src/store/path/windows.rs
@@ -71,7 +71,7 @@ mod tests {
 
     use std::ffi::OsStr;
     #[test]
-    fn test_encode_path() -> Result<()> {
+    fn test_encode_path() {
         let expected_path = PathBuf::from("/")
             .join("registry")
             .join(encode_filename("ghcr.io"))
@@ -86,12 +86,10 @@ mod tests {
         assert_eq!(expected_path, encode_path(OsStr::new(path)));
         assert_eq!(expected_path, encode_path(Path::new(path)));
         assert_eq!(expected_path, encode_path(Path::new(path)));
-
-        Ok(())
     }
 
     #[test]
-    fn test_decode_path() -> Result<()> {
+    fn test_decode_path() {
         assert_eq!(
             PathBuf::from("/registry/example.com:1234/some/path/to/wasm-module.wasm:1.0.0"),
             decode_path(
@@ -102,9 +100,8 @@ mod tests {
                     .join(encode_filename("path"))
                     .join(encode_filename("to"))
                     .join(encode_filename("wasm-module.wasm:1.0.0"))
-            )?,
+            )
+            .expect("failed to decode path"),
         );
-
-        Ok(())
     }
 }

--- a/tests/sources.rs
+++ b/tests/sources.rs
@@ -7,8 +7,8 @@ use tempfile::NamedTempFile;
 use textwrap::indent;
 
 #[test]
-fn test_read_sources_file() -> Result<(), Error> {
-    let mut sources_file = NamedTempFile::new()?;
+fn test_read_sources_file() {
+    let mut sources_file = NamedTempFile::new().unwrap();
 
     let expected_contents = r#"
 insecure_sources:
@@ -18,12 +18,13 @@ source_authorities:
     - type: Data
       data: |
 "#;
-    write!(sources_file, "{}", expected_contents)?;
+    write!(sources_file, "{}", expected_contents).unwrap();
     write!(
         sources_file,
         "{}",
         indent(common::CERT_DATA, "            ")
-    )?;
+    )
+    .unwrap();
 
     let expected_cert = Certificate::Pem(common::CERT_DATA.into());
     let path = sources_file.path();
@@ -46,5 +47,4 @@ source_authorities:
             panic!("Didn't get what I was expecting: {:?}", unexpected);
         }
     }
-    Ok(())
 }


### PR DESCRIPTION
## Description

As mentioned in this PR comment, we prefer not to use `Result` in tests: 

https://github.com/kubewarden/policy-fetcher/pull/152#discussion_r1311891401

This PR refactors the existing tests that do not comply.

## Test

-

## Additional Information

Maybe we could create a coding convention and guideline docs for all the rust projects.
This doc could collect testing-related information too: e.g. helper libraries to use, test organization, testing patterns, etc...