### PR TITLE
chore: bump v0.8.2.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "policy-fetcher"
-version = "0.8.1"
+version = "0.8.2"
 authors = [
+  "Kubewarden Developers <kubewarden@suse.de>",
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>",
   "Víctor Cuadrado Juan <vcuadradojuan@suse.de>",


### PR DESCRIPTION
## Description

Updates the Cargo.toml file bumping the version to v0.8.2.

Related to https://github.com/kubewarden/policy-evaluator/pull/429#issuecomment-1924541219