### PR TITLE
chore: use tarpaulin-install action to install tarpaulin.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,9 +77,7 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: taiki-e/install-action@5794068c211bc8f5f4514b7c3f03d6adbe66f1b7 # v2.26.18
-        with:
-          tool: cargo-tarpaulin
+      - uses: kubewarden/github-actions/tarpaulin-install@971e9a094d010900399dafc13fd4787bffce6d81 #v3.1.18
       - name: Generate unit-tests coverage
         run: make coverage-unit-tests
       - name: Upload unit-tests coverage to Codecov


### PR DESCRIPTION
## Description

Updates the ci.yaml workflow file to use the new github action created to install the cargo tarpaulin.

Related to https://github.com/kubewarden/kubewarden-controller/issues/667
