### PR TITLE
fix: do not use image url to get registry auth data.

### DIFF
--- a/src/verify/mod.rs
+++ b/src/verify/mod.rs
@@ -1,3 +1,4 @@
+use crate::registry::build_fully_resolved_reference;
 use crate::sources::Sources;
 use crate::{errors::FailedToParseYamlDataError, policy::Policy};
 
@@ -336,7 +337,8 @@ pub async fn fetch_sigstore_remote_data(
     }
 
     // obtain registry auth:
-    let auth = Registry::auth(image_url);
+    let reference = build_fully_resolved_reference(image_url)?;
+    let auth = Registry::auth(reference.registry());
 
     let sigstore_auth = match auth {
         RegistryAuth::Anonymous => sigstore::registry::Auth::Anonymous,


### PR DESCRIPTION
## Description

Updates the function used to verify container image signature to use only the registry name to get the auth data from docker config.json file. The current implementation uses the whole container image URL. Which failed to find the relevant auth data falling back to a anonymous authentication. This is a problem with private registries where access credentials must be used.

To fix this problem, this commit extract the registry name from the container image URL and use it to get the auth data from the config.json file.

Fix #179 

## Test

To test this pull request, you can build kwctl using this changes, execute a docker login in the private registry 

1. Generate private/public key pair with cosign
2. Sign docker image
3. Submit signed image to private harbor registry. You can use `demo.goharbor.io`
4. Create robot account in the harbor instance
5. Login into the private registry using the robot account: `docker login ...`
6. Build kwctl using this change
7. `kwctl run --settings-path settings.yaml --request-path pod_creation_signed.json registry://ghcr.io/kubewarden/policies/verify-image-signatures:v0.2.8`

**settings.yaml**

```yaml
signatures:
  - image: "PUT YOUR SIGNED CONTAINER IMAGE PREFIX HERE e.g: demo.goharbor.io/testing/*"  
    pubKeys:
      - |
        -----BEGIN PUBLIC KEY-----
       << YOUR COSIGN PUBLIC KEY >>>
        -----END PUBLIC KEY-----

```

 **pod_creation_signed.json**

```json
{
  "uid": "1299d386-525b-4032-98ae-1949f69f9cfc",
  "kind": {
    "group": "",
    "kind": "Pod",
    "version": "v1"
  },
  "resource": {
    "group": "",
    "version": "v1",
    "resource": "pods"
  },
  "object": {
    "metadata": {
      "name": "nginx"
    },
    "spec": {
      "containers": [
        {
          "image": "PUT YOUR SIGNED CONTAINER IMAGE HERE",
          "name": "test-verify-image-signatures"
        }
      ]
    }
  },
  "operation": "CREATE",
  "requestKind": {
    "group": "",
    "version": "v1",
    "kind": "Pod"
  },
  "userInfo": {
    "username": "alice",
    "uid": "alice-uid",
    "groups": [
      "system:authenticated"
    ]
  }
}

```