### PR TITLE
test: fix build on windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,9 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      - name: enable git long paths on Windows
+        if: matrix.os == 'windows-latest'
+        run: git config --global core.longpaths true
       - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
         with:
           command: test


### PR DESCRIPTION
Enable long paths on windows, otherwise git checkout of tough will fail.

Once merged, I'll tag a new release and propagate that to policy-evaluator. Otherwise kwctl will not build on windows
