### PR TITLE
feat: test if registry name is used to get credentials.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ tokio = { version = "1", default_features = false }
 cfg-if = "1.0"
 
 [dev-dependencies]
+mockall = "0.12.1"
 rstest = "0.19"
 tempfile = "3.2"
 textwrap = "0.16"
+tokio-test = "0.4.4"

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -28,6 +28,9 @@ use errors::RegistryError;
 
 use self::errors::RegistryResult;
 
+#[cfg(test)]
+use mockall::automock;
+
 pub mod errors;
 
 lazy_static! {
@@ -93,6 +96,8 @@ impl From<ClientProtocol> for ClientConfig {
     }
 }
 
+#[cfg_attr(test, automock)]
+#[cfg_attr(test, allow(dead_code))]
 impl Registry {
     pub fn new() -> Registry {
         Registry {}
@@ -125,10 +130,10 @@ impl Registry {
     }
 
     /// Fetch the manifest of the OCI object referenced by the given url.
-    pub async fn manifest(
+    pub async fn manifest<'a>(
         &self,
         url: &str,
-        sources: Option<&Sources>,
+        sources: Option<&'a Sources>,
     ) -> RegistryResult<oci_distribution::manifest::OciManifest> {
         // Start by building the Reference, this will expand the input url to
         // ensure it contains also the registry. Example: `busybox` ->
@@ -147,10 +152,10 @@ impl Registry {
     }
 
     /// Fetch the manifest's digest of the OCI object referenced by the given url.
-    pub async fn manifest_digest(
+    pub async fn manifest_digest<'a>(
         &self,
         url: &str,
-        sources: Option<&Sources>,
+        sources: Option<&'a Sources>,
     ) -> RegistryResult<String> {
         // Start by building the Reference, this will expand the input url to
         // ensure it contains also the registry. Example: `busybox` ->
@@ -170,11 +175,11 @@ impl Registry {
     ///
     /// Returns the immutable reference to the policy (i.e.
     /// `ghcr.io/kubewarden/secure-policy@sha256:72b4569c3daee67abeaa64192fb53895d0edb2d44fa6e1d9d4c5d3f8ece09f6e`)
-    pub async fn push(
+    pub async fn push<'a>(
         &self,
         policy: &[u8],
         destination: &str,
-        sources: Option<&Sources>,
+        sources: Option<&'a Sources>,
     ) -> RegistryResult<String> {
         let url = Url::parse(destination)
             .map_err(|_| crate::errors::InvalidURLError(destination.to_owned()))?;


### PR DESCRIPTION
## Description

Recently, we have merged a fix to use the registry name to get the credentials to access private registry from the docker config file. Before that, the code was using the whole container image name. Therefore, no credentials was not being found and causing issues when trying to interact with the private registries.

To avoid that issue happens again, this commit adds a new unit test to avoid a regression for this bug.

Fix #181 

## Test

```shell
make test
```
