### PR TITLE
update sigstore

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 sha2 = "0.10"
-sigstore = { git = "https://github.com/flavio/sigstore-rs.git", rev = "46b1cb63b193ab3402beeae5b4999c42cfc65e43", default-features = false, features = [
+sigstore = { git = "https://github.com/flavio/sigstore-rs.git", branch = "kubewarden", default-features = false, features = [
   "sigstore-trust-root",
   "cosign-rustls-tls",
   "cached-client",

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -272,7 +272,7 @@ mod tests {
     ) {
         let default = Store::default();
         let path = default.policy_full_path(input_url, input_policy_path);
-        assert!(matches!(path, Ok(_)));
+        assert!(path.is_ok());
         assert_eq!(
             default.root.join(path::encode_path(expected_relative_path)),
             path.unwrap_or_default()

--- a/src/verify/config.rs
+++ b/src/verify/config.rs
@@ -230,12 +230,13 @@ mod tests {
         #subject:
         #   urlPrefix: https://github.com/kubewarden/
     "#;
-        let error = build_latest_verification_config(config);
-        print!("{:?}", error);
-        let expected_msg = "Not a valid configuration file: missing field `subject`";
-        assert!(
-            matches!(error, Err(VerifyError::InvalidVerifyFileError(msg)) if msg.to_string() == expected_msg)
-        );
+        match build_latest_verification_config(config) {
+            Err(VerifyError::InvalidVerifyFileError(msg)) => assert_eq!(
+                msg,
+                "Not a valid configuration file: missing field `subject`"
+            ),
+            _ => panic!("expected an error"),
+        }
     }
 
     #[test]

--- a/src/verify/mod.rs
+++ b/src/verify/mod.rs
@@ -28,16 +28,16 @@ pub mod verification_constraints;
 /// This structure simplifies the process of policy verification
 /// using Sigstore
 #[derive(Clone)]
-pub struct Verifier<'a> {
-    cosign_client: Arc<Mutex<sigstore::cosign::Client<'a>>>,
+pub struct Verifier {
+    cosign_client: Arc<Mutex<sigstore::cosign::Client>>,
     sources: Option<Sources>,
 }
 
-impl<'a> Verifier<'a> {
+impl Verifier {
     /// Creates a new verifier that leverages an already existing
     /// Cosign client.
     pub fn new_from_cosign_client(
-        cosign_client: Arc<Mutex<sigstore::cosign::Client<'a>>>,
+        cosign_client: Arc<Mutex<sigstore::cosign::Client>>,
         sources: Option<Sources>,
     ) -> Self {
         Self {
@@ -61,16 +61,14 @@ impl<'a> Verifier<'a> {
             Some(trust_root) => {
                 cosign_client_builder =
                     cosign_client_builder.with_trust_repository(trust_root.as_ref())?;
-                let cosign_client = cosign_client_builder.build()?;
-                cosign_client.to_owned()
+                cosign_client_builder.build()?
             }
             None => {
                 warn!("Sigstore Verifier created without Fulcio data: keyless signatures are going to be discarded because they cannot be verified");
                 warn!("Sigstore Verifier created without Rekor data: transparency log data won't be used");
                 warn!("Sigstore capabilities are going to be limited");
 
-                let cosign_client = cosign_client_builder.build()?;
-                cosign_client.to_owned()
+                cosign_client_builder.build()?
             }
         };
 
@@ -272,8 +270,8 @@ fn verify_signatures_against_config(
 /// Returns:
 /// * String holding the source image digest
 /// * List of signature layers
-pub async fn fetch_sigstore_remote_data<'a>(
-    cosign_client_input: &Arc<Mutex<cosign::Client<'a>>>,
+pub async fn fetch_sigstore_remote_data(
+    cosign_client_input: &Arc<Mutex<cosign::Client>>,
     image_url: &str,
 ) -> VerifyResult<(String, Vec<SignatureLayer>)> {
     let mut cosign_client = cosign_client_input.lock().await;

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -100,14 +100,14 @@ mod e2e {
         let image: Reference = POLICY_IMAGE_TAG.parse().unwrap();
         let anonymous_auth = &RegistryAuth::Anonymous;
 
-        return client
+        client
             .pull(
                 &image,
                 anonymous_auth,
                 vec![manifest::WASM_LAYER_MEDIA_TYPE],
             )
             .await
-            .expect("failed to pull manifest");
+            .expect("failed to pull manifest")
     }
 
     async fn push_image_to_test_registry(client: Client, port: u16, image: ImageData) -> Reference {
@@ -148,19 +148,18 @@ mod e2e {
     /// Creates the docker config.json file with the credentials to be
     /// used to pull the image from the registry
     fn create_docker_config_file(auth_dir: &TempDir, port: u16) {
-        let auth_string = BASE64_STANDARD_NO_PAD
-            .encode(format!("{}:{}", REGISTRY_USER, REGISTRY_PASSWORD).to_owned());
+        let auth_string =
+            BASE64_STANDARD_NO_PAD.encode(format!("{}:{}", REGISTRY_USER, REGISTRY_PASSWORD));
         let docker_auth_config = format!(
             r#"
     {{
         "auths": {{
-            "{}": {{
+            "localhost:{}": {{
                 "auth": "{}"
             }}
         }}
     }}"#,
-            format!("localhost:{}", port),
-            auth_string,
+            port, auth_string,
         )
         .to_owned();
         let docker_config_path = path::Path::join(auth_dir.path(), "config.json");


### PR DESCRIPTION
Update the code to build with the latest version of sigstore available inside of upstream's main branch.

Note: we still have to consume a fork of sigstore, because we need to have two small patches on top of the upstream code. However, with this PR we will be using latest API of sigstore, which is pretty important.
