### PR TITLE
feat: method to get manifest and config of an OCI image.

### DIFF
--- a/src/registry/errors.rs
+++ b/src/registry/errors.rs
@@ -18,4 +18,6 @@ pub enum RegistryError {
     UrlParserError(#[from] url::ParseError),
     #[error(transparent)]
     InvalidURLError(#[from] InvalidURLError),
+    #[error(transparent)]
+    JSONParseError(#[from] serde_json::Error),
 }


### PR DESCRIPTION
## Description

Updates the registry client adding a method to fetch the container image manifest, its digest and configuration.

Fix https://github.com/kubewarden/policy-evaluator/issues/518

## Test

To test this pull request, you can run the following commands:


```shell
make test
```