### PR TITLE
chore: bump version to v0.8.6.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-fetcher"
-version = "0.8.5"
+version = "0.8.6"
 authors = [
   "Kubewarden Developers <kubewarden@suse.de>",
   "Flavio Castelli <fcastelli@suse.com>",


### PR DESCRIPTION
## Description

Bumps the version to v0.8.6 to release new method added to get the OCI image manifest and config from the registry.

Related to https://github.com/kubewarden/policy-evaluator/issues/518
