### PR TITLE
Bumps v0.8.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-fetcher"
-version = "0.8.5"
+version = "0.8.7"
 authors = [
   "Kubewarden Developers <kubewarden@suse.de>",
   "Flavio Castelli <fcastelli@suse.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-fetcher"
-version = "0.8.6"
+version = "0.8.5"
 authors = [
   "Kubewarden Developers <kubewarden@suse.de>",
   "Flavio Castelli <fcastelli@suse.com>",


### PR DESCRIPTION
## Description

This reverts commit 53518be2244d3daeee66357eb48ab6aace06e614, reversing changes made to d46093f5a5aa52500ba4e31352f6c44a88e8b94f. This is necessary because the v0.8.6 is already accidentally released in a commit out of tree.

Furthermore, it bumps the version to v0.8.7 to release new method added to get the OCI image manifest and config from the registry.


Related to https://github.com/kubewarden/policy-evaluator/issues/518
