### PR TITLE
fix(tests): disables auth registry tests on windows.

### DIFF
--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -178,6 +178,7 @@ mod e2e {
         std::env::set_var("DOCKER_CONFIG", auth_dir.path());
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn test_fetch_sigstore_data_from_registry_with_authentication() {
         let (registry_image, auth_dir) = setup_registry_image();


### PR DESCRIPTION
## Description

Disable the tests to validate the registry authentication on Windows. The test uses the registry container image which is not supported on Windows.

Fix #193 

