### PR TITLE
fix: ensure consumers of policy-fetcher can compile

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,7 +203,7 @@ fn pull_destination(
 // Helper function, takes the URL of the policy and allocates the
 // right struct to interact with it
 #[allow(clippy::box_default)]
-fn url_fetcher(scheme: &str) -> StoreResult<Box<dyn PolicyFetcher>> {
+fn url_fetcher(scheme: &str) -> StoreResult<Box<dyn PolicyFetcher + Send>> {
     match scheme {
         "http" | "https" => Ok(Box::new(Https::default())),
         "registry" => Ok(Box::new(Registry::new())),


### PR DESCRIPTION
Under special circumstances, some code that makes uses of policy-fetcher does not compile.

That happens when the consumer of policy-fetcher is created inside of a tokio task with `tokio::spawn()`.

That happens because the private `url_fetcher` takes as a parameter something that implements the `PolicyFetcher` trait, but is not explicit about requiring also the `Send` attribute. The `Send` attribute is required by tokio to move the task between its worker threads.

Once this is merged I'll tag a new patch release of the crate. This is required by the integration tests of `policy-server` to test the certificate reload.
