### PR TITLE
chore(deps): oci-distribution has been renamed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ async-trait = "0.1"
 base64 = "0.22"
 directories = "5.0"
 lazy_static = "1.4"
-oci-distribution = { version = "0.11", default-features = false, features = [
+oci-client = { version = "0.11", default-features = false, features = [
   "rustls-tls",
 ] }
 path-slash = "0.2"
@@ -51,7 +51,7 @@ url = { version = "2.2", features = ["serde"] }
 walkdir = "2"
 rayon = "1.5"
 docker_credential = "1.2"
-tokio = { version = "1", default_features = false }
+tokio = { version = "1", default-features = false }
 cfg-if = "1.0"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ use tracing::debug;
 use url::ParseError;
 
 // re-export for usage by kwctl, policy-server, policy-evaluator,...
-pub use oci_distribution;
+pub use oci_client;
 pub use sigstore;
 
 lazy_static! {

--- a/src/registry/errors.rs
+++ b/src/registry/errors.rs
@@ -7,9 +7,9 @@ pub type RegistryResult<T> = std::result::Result<T, RegistryError>;
 #[derive(Error, Debug)]
 pub enum RegistryError {
     #[error("Fail to interact with OCI registry: {0}")]
-    OCIRegistryError(#[from] oci_distribution::errors::OciDistributionError),
+    OCIRegistryError(#[from] oci_client::errors::OciDistributionError),
     #[error("Invalid OCI image reference: {0}")]
-    InvalidOCIImageReferenceError(#[from] oci_distribution::ParseError),
+    InvalidOCIImageReferenceError(#[from] oci_client::ParseError),
     #[error("{0}")]
     BuildImmutableReferenceError(String),
     #[error("Invalid destination format")]

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use docker_credential::DockerCredential;
 use lazy_static::lazy_static;
-use oci_distribution::{
+use oci_client::{
     client::{
         Certificate as OciCertificate, CertificateEncoding, Client, ClientConfig,
         ClientProtocol as OciClientProtocol, Config, ImageLayer,
@@ -129,7 +129,7 @@ impl Registry {
         &self,
         url: &str,
         sources: Option<&Sources>,
-    ) -> RegistryResult<oci_distribution::manifest::OciManifest> {
+    ) -> RegistryResult<oci_client::manifest::OciManifest> {
         // Start by building the Reference, this will expand the input url to
         // ensure it contains also the registry. Example: `busybox` ->
         // `docker.io/library/busybox:latest`
@@ -254,7 +254,7 @@ impl Registry {
         url: &str,
         sources: Option<&Sources>,
     ) -> RegistryResult<(
-        oci_distribution::manifest::OciImageManifest,
+        oci_client::manifest::OciImageManifest,
         String,
         serde_json::Value,
     )> {
@@ -340,7 +340,7 @@ fn build_immutable_ref(image_ref: &str, manifest_url: &str) -> RegistryResult<St
         )));
     }
 
-    let oci_reference = oci_distribution::Reference::try_from(image_ref)?;
+    let oci_reference = oci_client::Reference::try_from(image_ref)?;
     let mut image_immutable_ref = if oci_reference.registry() == "" {
         oci_reference.repository().to_string()
     } else {

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -14,9 +14,9 @@ pub enum SourceError {
     #[error(transparent)]
     InvalidURLError(#[from] crate::errors::InvalidURLError),
     #[error("Fail to interact with OCI registry: {0}")]
-    OCIRegistryError(#[from] oci_distribution::errors::OciDistributionError),
+    OCIRegistryError(#[from] oci_client::errors::OciDistributionError),
     #[error("Invalid OCI image reference: {0}")]
-    InvalidOCIImageReferenceError(#[from] oci_distribution::ParseError),
+    InvalidOCIImageReferenceError(#[from] oci_client::ParseError),
     #[error("could not pull policy {0}: empty layers")]
     EmptyLayersError(String),
     #[error("Invalid certificate: {0}")]
@@ -170,16 +170,16 @@ impl<'a> TryFrom<&Certificate> for rustls_pki_types::CertificateDer<'a> {
     }
 }
 
-impl From<Sources> for oci_distribution::client::ClientConfig {
+impl From<Sources> for oci_client::client::ClientConfig {
     fn from(sources: Sources) -> Self {
         let protocol = if sources.insecure_sources.is_empty() {
-            oci_distribution::client::ClientProtocol::Https
+            oci_client::client::ClientProtocol::Https
         } else {
             let insecure: Vec<String> = sources.insecure_sources.iter().cloned().collect();
-            oci_distribution::client::ClientProtocol::HttpsExcept(insecure)
+            oci_client::client::ClientProtocol::HttpsExcept(insecure)
         };
 
-        let extra_root_certificates: Vec<oci_distribution::client::Certificate> = sources
+        let extra_root_certificates: Vec<oci_client::client::Certificate> = sources
             .source_authorities
             .0
             .iter()
@@ -187,11 +187,11 @@ impl From<Sources> for oci_distribution::client::ClientConfig {
                 certs
                     .iter()
                     .map(|c| c.into())
-                    .collect::<Vec<oci_distribution::client::Certificate>>()
+                    .collect::<Vec<oci_client::client::Certificate>>()
             })
             .collect();
 
-        oci_distribution::client::ClientConfig {
+        oci_client::client::ClientConfig {
             protocol,
             accept_invalid_certificates: false,
             extra_root_certificates,

--- a/src/verify/errors.rs
+++ b/src/verify/errors.rs
@@ -15,7 +15,7 @@ pub enum VerifyError {
     #[error("{0}")]
     InvalidVerifyFileError(String),
     #[error("Verification only works with OCI images: Not a valid oci image: {0}")]
-    InvalidOCIImageReferenceError(#[from] oci_distribution::ParseError),
+    InvalidOCIImageReferenceError(#[from] oci_client::ParseError),
     #[error("key verification failure: {0} ")]
     KeyVerificationError(#[source] sigstore::errors::SigstoreError),
     // The next error is more specialized error based on a sigstore error. It must

--- a/src/verify/mod.rs
+++ b/src/verify/mod.rs
@@ -1,4 +1,4 @@
-use oci_distribution::{manifest::WASM_LAYER_MEDIA_TYPE, secrets::RegistryAuth, Reference};
+use oci_client::{manifest::WASM_LAYER_MEDIA_TYPE, secrets::RegistryAuth, Reference};
 use sigstore::{
     cosign::{self, signature_layers::SignatureLayer, ClientBuilder, CosignCapabilities},
     errors::SigstoreError,
@@ -135,7 +135,7 @@ impl Verifier {
         }
 
         let registry = crate::registry::Registry::new();
-        let reference = oci_distribution::Reference::from_str(image_name)?;
+        let reference = oci_client::Reference::from_str(image_name)?;
         let image_immutable_ref = format!(
             "registry://{}/{}@{}",
             reference.registry(),
@@ -146,9 +146,8 @@ impl Verifier {
             .manifest(&image_immutable_ref, self.sources.as_ref())
             .await?;
 
-        let digests: Vec<String> = if let oci_distribution::manifest::OciManifest::Image(
-            ref image,
-        ) = manifest
+        let digests: Vec<String> = if let oci_client::manifest::OciManifest::Image(ref image) =
+            manifest
         {
             image
                 .layers

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -6,7 +6,7 @@
 mod e2e {
 
     use base64::prelude::{Engine as _, BASE64_STANDARD_NO_PAD};
-    use oci_distribution::{client::ImageData, manifest, secrets::RegistryAuth, Client, Reference};
+    use oci_client::{client::ImageData, manifest, secrets::RegistryAuth, Client, Reference};
     use policy_fetcher::registry::Registry;
     use policy_fetcher::verify::fetch_sigstore_remote_data;
     use sigstore::cosign::{
@@ -134,8 +134,8 @@ mod e2e {
 
     /// Loads a policy image into the registry running in the given port and signs it
     async fn push_container_image(port: u16) -> (Reference, Box<dyn VerificationConstraint>) {
-        let client = Client::new(oci_distribution::client::ClientConfig {
-            protocol: oci_distribution::client::ClientProtocol::HttpsExcept(vec![format!(
+        let client = Client::new(oci_client::client::ClientConfig {
+            protocol: oci_client::client::ClientProtocol::HttpsExcept(vec![format!(
                 "localhost:{}",
                 port
             )]),


### PR DESCRIPTION
The crate is now called `oci-client`.

Once this is merged, I'll tag a new release of policy-fetcher and propagate the change to kwctl, policy-server and policy-evaluator
