### PR TITLE
add more logging

### DIFF
--- a/src/fetcher.rs
+++ b/src/fetcher.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use async_trait::async_trait;
 use url::Url;
 
@@ -9,11 +11,30 @@ pub(crate) enum ClientProtocol {
     Https(TlsVerificationMode),
 }
 
+impl fmt::Display for ClientProtocol {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ClientProtocol::Http => write!(f, "HTTP"),
+            ClientProtocol::Https(mode) => write!(f, "HTTPS({})", mode),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) enum TlsVerificationMode {
     CustomCaCertificates(Vec<Certificate>),
     SystemCa,
     NoTlsVerification,
+}
+
+impl fmt::Display for TlsVerificationMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TlsVerificationMode::CustomCaCertificates(_) => write!(f, "CustomCaCertificates"),
+            TlsVerificationMode::SystemCa => write!(f, "SystemCa"),
+            TlsVerificationMode::NoTlsVerification => write!(f, "NoTlsVerification"),
+        }
+    }
 }
 
 // Generic interface for all the operations related with obtaining

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -152,7 +152,7 @@ impl From<&Certificate> for sigstore::registry::Certificate {
     }
 }
 
-impl<'a> TryFrom<&Certificate> for rustls_pki_types::CertificateDer<'a> {
+impl TryFrom<&Certificate> for rustls_pki_types::CertificateDer<'_> {
     type Error = &'static str;
 
     fn try_from(cert: &Certificate) -> std::result::Result<Self, Self::Error> {


### PR DESCRIPTION
Add more logging statements when pushing to an insecure registry.
    
We had a user that was struggling to understand why pushing to a certain registry didn't work despite `insecure` being turned on.
    
We finally figured out that was happening because of a reverse proxy was misconfigured. However, the error obtained from the insecure proxy was silently swallowed.
 

Moreover, I fixed some clippy warnings introduced by latest release of Rust
