### PR TITLE
fix: address broken sigstore's TUF repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-fetcher"
-version = "0.8.13"
+version = "0.8.14"
 authors = [
   "Kubewarden Developers <kubewarden@suse.de>",
   "Flavio Castelli <fcastelli@suse.com>",
@@ -36,7 +36,7 @@ serde_json = "1.0"
 serde_yaml = "0.9"
 serde_bytes = "0.11"
 sha2 = "0.10"
-sigstore = { version = "0.10", default-features = false, features = [
+sigstore = { git = "https://github.com/flavio/sigstore-rs.git", tag = "v0.10.0+tough-keyid-patch-1", default-features = false, features = [
   "sigstore-trust-root-rustls-tls",
   "cosign-rustls-tls",
   "cached-client",


### PR DESCRIPTION
The contents of Sigstore's TUF repository have been recently changed and, due to a mistake, the sigstore-rs was broken.

This commit consumes a forked version of sigstore-rs, which consumes a forked version of the tough crate.

This is required to fix https://github.com/sigstore/sigstore-rs/issues/429 until upstream changes the contents of TUF's repository.
