### PR TITLE
fix: http registry interactions

### DIFF
--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,5 @@
+[formatting]
+align_entries  = true
+reorder_arrays = true
+reorder_keys   = true
+sort_keys      = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 edition = "2021"
 name = "policy-fetcher"
-version = "0.9.0"
+version = "0.10.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,59 +1,61 @@
 [package]
-name = "policy-fetcher"
-version = "0.9.0"
 authors = [
-  "Kubewarden Developers <kubewarden@suse.de>",
+  "Fabrizio Sestito <fabrizio.sestito@suse.com>",
   "Flavio Castelli <fcastelli@suse.com>",
+  "Kubewarden Developers <kubewarden@suse.de>",
   "Rafael Fernández López <rfernandezlopez@suse.com>",
   "Víctor Cuadrado Juan <vcuadradojuan@suse.de>",
-  "Fabrizio Sestito <fabrizio.sestito@suse.com>",
 ]
 edition = "2021"
+name = "policy-fetcher"
+version = "0.9.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 async-trait = "0.1"
 base64 = "0.22"
+cfg-if = "1.0"
 directories = "6.0"
+docker_credential = "1.2"
+futures = "0.3"
 lazy_static = "1.4"
 oci-client = { version = "0.14", default-features = false, features = [
   "rustls-tls",
 ] }
 path-slash = "0.2"
+rayon = "1.5"
 regex = "1.5"
 reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls",
 ] }
 rustls = { version = "0.23", default-features = false, features = [
-  "std",
   "ring",
+  "std",
   "tls12",
 ] }
 rustls-pki-types = "1.0.1" # stick to the same version used by sigstore
 serde = { version = "1.0", features = ["derive"] }
+serde_bytes = "0.11"
 serde_json = "1.0"
 serde_yaml = "0.9"
-serde_bytes = "0.11"
 sha2 = "0.10"
 sigstore = { version = "0.11.0", default-features = false, features = [
-  "sigstore-trust-root-rustls-tls",
-  "cosign-rustls-tls",
   "cached-client",
+  "cosign-rustls-tls",
+  "sigstore-trust-root-rustls-tls",
 ] }
 thiserror = "2.0"
+tokio = { version = "1", default-features = false }
 tracing = "0.1"
 url = { version = "2.2", features = ["serde"] }
 walkdir = "2.5"
-rayon = "1.5"
-docker_credential = "1.2"
-tokio = { version = "1", default-features = false }
-cfg-if = "1.0"
 x509-parser = "0.17"
 
 [dev-dependencies]
-rstest = "0.24"
-tempfile = "3.2"
-textwrap = "0.16"
+anyhow         = "1.0"
+rcgen          = "0.13"
+rstest         = "0.24"
+tempfile       = "3.2"
 testcontainers = { version = "0.23", features = ["http_wait"] }
-anyhow = "1.0"
+textwrap       = "0.16"

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -80,7 +80,7 @@ struct RawSources {
 struct RawCertificate(#[serde(with = "serde_bytes")] Vec<u8>);
 
 #[derive(Clone, Debug, Default)]
-struct SourceAuthorities(HashMap<String, Vec<Certificate>>);
+pub struct SourceAuthorities(pub HashMap<String, Vec<Certificate>>);
 
 impl TryFrom<RawSourceAuthorities> for SourceAuthorities {
     type Error = SourceError;
@@ -105,8 +105,8 @@ impl TryFrom<RawSourceAuthorities> for SourceAuthorities {
 
 #[derive(Clone, Debug, Default)]
 pub struct Sources {
-    insecure_sources: HashSet<String>,
-    source_authorities: SourceAuthorities,
+    pub insecure_sources: HashSet<String>,
+    pub source_authorities: SourceAuthorities,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
Prior to this PR, some methods exposed by the `Registry` struct did not handle properly interactions with HTTP registries.

This made impossible to fetch OCI manifests and configurations from certain registries.

This commit fixes the problem and refactors the code to avoid repetitions.

New e2e tests have been added that interact with http and https registries.

Finally, some structs internals have been made public to simplify the process of creating them.

For example, the `Sources` struct could be created only by deserializing the contents of a `sources.yaml` file. This made testing (and library consumpion) really hard.
    
While working on this PR, I've also added a [taplo](https://taplo.tamasfe.dev/) configuration that can be used to format the `Cargo.toml` file in a consistent way.
