### PR TITLE
fix: change log level when pushing policy

### DIFF
--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -262,7 +262,7 @@ impl Registry {
         annotations: Option<&BTreeMap<String, String>>,
         client_protocol: ClientProtocol,
     ) -> RegistryResult<String> {
-        warn!(client_protocol = ?client_protocol, "pushing policy");
+        debug!(client_protocol = ?client_protocol, "pushing policy");
         let reference =
             Reference::from_str(url.as_ref().strip_prefix("registry://").unwrap_or_default())?;
 


### PR DESCRIPTION
Use `debug` instead of `warn` level when pushing a policy. This reduces the noise we produce when doing `kwctl push`.
