### PR TITLE
fix(deps): remove deprecated actions-rs/cargo Github action.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,9 +13,8 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
-        with:
-          command: check
+      - name: Run cargo check
+        run: cargo check
 
   test:
     name: Test Suite
@@ -33,10 +32,8 @@ jobs:
       - name: enable git long paths on Windows
         if: matrix.os == 'windows-latest'
         run: git config --global core.longpaths true
-      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
-        with:
-          command: test
-          args: --workspace
+      - name: Run cargo test
+        run: cargo test --workspace
 
   fmt:
     name: Rustfmt
@@ -49,10 +46,8 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt
-      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
-        with:
-          command: fmt
-          args: --all -- --check
+      - name: "Run cargo fmt"
+        run: cargo fmt --all -- --check
 
   clippy:
     name: Clippy
@@ -65,10 +60,8 @@ jobs:
           toolchain: stable
           override: true
           components: clippy
-      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
-        with:
-          command: clippy
-          args: -- -D warnings
+      - name: "Run cargo clippy"
+        run: cargo clippy -- -D warnings
 
   spelling:
     name: Spell Check with Typos


### PR DESCRIPTION
## Description

Removes the deprecated actions-rs/cargo Github action used to run cargo commands.

Related to https://github.com/kubewarden/kubewarden-controller/issues/1092
